### PR TITLE
Add polished bilingual READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,86 @@
+# Bilibili Accelerator
+
+[中文](./README.md)
+
+Bilibili should not buffer every few seconds just because you are watching from overseas.
+
+**Bilibili Accelerator** is a userscript that rewrites slow Bilibili playback CDN URLs before the player starts buffering. It targets the usual overseas pain points: `upos-*ov` mirror hosts, MCDN/PCDN nodes, and route choices that make niche videos stutter while popular videos play fine.
+
+## Install
+
+Greasy Fork is the recommended install path. It works with Chrome, Safari, Firefox, and Edge through a userscript manager.
+
+- [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+- [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
+- [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
+- [GitHub Release v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
+
+After installation, open any Bilibili video. A small `BA` button in the lower-right corner means the script is active.
+
+## Chrome / Edge
+
+1. Install [Tampermonkey](https://www.tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/).
+2. Open the [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator).
+3. Click Install.
+4. Reload the Bilibili video page.
+
+You can also load the unpacked extension:
+
+```sh
+npm run build
+```
+
+Then open `chrome://extensions`, enable Developer mode, and select `dist/extension`.
+
+## Safari
+
+1. Install the Safari extension [Userscripts](https://apps.apple.com/us/app/userscripts/id1463298887).
+2. Enable Userscripts in Safari Settings and allow it on `bilibili.com`.
+3. Open the [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) or the [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js).
+4. Install when prompted, then reload the Bilibili video page.
+
+## What It Changes
+
+Bilibili often returns multiple signed media URLs for the same video. Overseas viewers may get routed to hosts like:
+
+```text
+upos-sz-mirrorcosov.bilivideo.com
+xy153x35x231x78xy.mcdn.bilivideo.cn:8082
+```
+
+The script rewrites those slow paths to steadier playback routes, by default:
+
+```text
+upos-sz-mirrorcos.bilivideo.com
+proxy-tf-all-ws.bilivideo.com
+```
+
+Healthy CDN URLs are left alone by default. For stubborn videos, open the `BA` panel, enable `Force all video CDN`, and reload.
+
+## Tested Case
+
+This reported stuttery video:
+
+```text
+https://www.bilibili.com/video/BV1NnVK6cEXs
+```
+
+returned `upos-sz-mirrorcosov.bilivideo.com` playback URLs. The script rewrites them to `upos-sz-mirrorcos.bilivideo.com`.
+
+## Development
+
+```sh
+npm test
+npm run build
+```
+
+Outputs:
+
+```text
+dist/bilibili-accelerator.user.js
+dist/extension/
+```
+
+## Why Star This
+
+If you watch Bilibili overseas, this turns a lot of mysterious buffering into one small, controllable switch.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,63 @@
-# 海外b站，为什么这么慢
+# Bilibili Accelerator：海外 B 站加速
 
-海外看 B 站，冷门视频不该像抽卡一样一会儿流畅、一会儿卡死。
+[English](./README.en.md)
 
-这个小插件会在播放器开始缓冲前，自动改写 Bilibili 返回的慢 CDN 播放地址。它主要处理海外用户常见的卡顿源：`upos-*ov` 海外镜像、MCDN/PCDN 节点，以及某些对你所在网络路由很差的播放 host。
+海外看 B 站，热门视频通常还行，冷门视频却经常一会儿流畅、一会儿卡死。
 
-## 一句话安装
+**Bilibili Accelerator** 是一个用户脚本。它会在播放器开始缓冲前，自动改写 Bilibili 返回的慢 CDN 播放地址，专治海外网络下常见的 `upos-*ov` 海外镜像、MCDN/PCDN 节点和糟糕路由。
 
-装一个用户脚本管理器，然后点安装：
+## 立即安装
 
-- Tampermonkey / Violentmonkey / Userscripts：
-  [安装 GitHub 版](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- GitHub Release：
-  [下载 v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
-- Greasy Fork：
-  [官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+推荐从 Greasy Fork 安装，Chrome、Safari、Firefox、Edge 都可以用。
 
-装好后打开任意 B 站视频，右下角出现 `BA` 按钮，就说明生效了。
+- [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+- [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
+- [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
+- [GitHub Release v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
 
-## Safari 安装
+装好后打开任意 B 站视频。右下角出现 `BA` 按钮，就说明脚本已经生效。
+
+## Chrome / Edge
+
+1. 安装 [Tampermonkey](https://www.tampermonkey.net/) 或 [Violentmonkey](https://violentmonkey.github.io/)。
+2. 打开 [Greasy Fork 脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)。
+3. 点击 Install。
+4. 刷新 B 站视频页。
+
+也可以加载解压扩展：
+
+```sh
+npm run build
+```
+
+然后打开 `chrome://extensions`，开启「开发者模式」，选择 `dist/extension`。
+
+## Safari
 
 1. 安装 Safari 扩展 [Userscripts](https://apps.apple.com/us/app/userscripts/id1463298887)。
 2. 在 Safari 设置里启用 Userscripts，并允许访问 `bilibili.com`。
-3. 打开：
+3. 打开 [Greasy Fork 脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) 或 [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)。
+4. Userscripts 提示安装后，刷新 B 站视频页。
 
-```text
-https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js
-```
+## 它改了什么
 
-4. Userscripts 会提示安装。安装后刷新 B 站视频页。
-
-## Chrome 安装
-
-推荐用 Tampermonkey：
-
-1. 安装 [Tampermonkey](https://www.tampermonkey.net/) 或 [Violentmonkey](https://violentmonkey.github.io/)。
-2. 打开：
-
-   ```text
-   https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js
-   ```
-
-3. Tampermonkey 会弹出安装页，点 Install。
-4. 打开 B 站视频页。
-
-也可以用解压扩展方式：
-
-1. 运行：
-
-   ```sh
-   npm run build
-   ```
-
-2. 打开 Chrome 扩展管理页：
-
-   ```text
-   chrome://extensions
-   ```
-
-3. 开启「开发者模式」。
-4. 点击「加载已解压的扩展程序」。
-5. 选择：
-
-   ```text
-   dist/extension
-   ```
-
-## 它到底改了什么
-
-Bilibili 会给同一个视频返回多条带签名的媒体 URL。海外网络下，冷门视频常被分到这种地址：
+Bilibili 会给同一个视频返回多条带签名的媒体 URL。海外网络下，冷门视频常被分到这些地址：
 
 ```text
 upos-sz-mirrorcosov.bilivideo.com
 xy153x35x231x78xy.mcdn.bilivideo.cn:8082
 ```
 
-插件会把这些慢路径换成更稳的播放路径，默认类似这样：
+脚本会把慢路径换成更稳的播放路径，默认类似：
 
 ```text
 upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-正常 CDN 不会乱动。除非你在 `BA` 面板里打开 `Force all video CDN`。
+正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 `BA`，开启 `Force all video CDN` 后刷新。
 
-## 已测卡顿样本
+## 已测样本
 
 这个视频曾被反馈特别卡：
 
@@ -91,7 +65,7 @@ proxy-tf-all-ws.bilivideo.com
 https://www.bilibili.com/video/BV1NnVK6cEXs
 ```
 
-页面播放数据里返回了 `upos-sz-mirrorcosov.bilivideo.com`。插件会自动改成 `upos-sz-mirrorcos.bilivideo.com`。
+页面播放数据返回了 `upos-sz-mirrorcosov.bilivideo.com`。脚本会自动改成 `upos-sz-mirrorcos.bilivideo.com`。
 
 ## 开发
 
@@ -100,26 +74,13 @@ npm test
 npm run build
 ```
 
-输出文件：
+输出：
 
 ```text
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
 
-## 发布
-
-- GitHub raw 安装源：
-  `https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js`
-- GitHub Release：
-  `https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1`
-- Tampermonkey：
-  打开 GitHub raw 安装源即可触发安装页。
-- Greasy Fork：
-  `https://greasyfork.org/en/scripts/582026-bilibili-accelerator`
-- Greasy Fork 安装源：
-  `https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js`
-
 ## 为什么值得 Star
 
-因为人在海外，看 B 站也应该是在看视频，不是在修网络。
+如果你也在海外看 B 站，这个项目能把很多“玄学卡顿”变成一个可控开关。

--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -1,0 +1,86 @@
+# Bilibili Accelerator
+
+[中文](./README.md)
+
+Bilibili should not buffer every few seconds just because you are watching from overseas.
+
+**Bilibili Accelerator** is a userscript that rewrites slow Bilibili playback CDN URLs before the player starts buffering. It targets the usual overseas pain points: `upos-*ov` mirror hosts, MCDN/PCDN nodes, and route choices that make niche videos stutter while popular videos play fine.
+
+## Install
+
+Greasy Fork is the recommended install path. It works with Chrome, Safari, Firefox, and Edge through a userscript manager.
+
+- [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+- [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
+- [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
+- [GitHub Release v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
+
+After installation, open any Bilibili video. A small `BA` button in the lower-right corner means the script is active.
+
+## Chrome / Edge
+
+1. Install [Tampermonkey](https://www.tampermonkey.net/) or [Violentmonkey](https://violentmonkey.github.io/).
+2. Open the [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator).
+3. Click Install.
+4. Reload the Bilibili video page.
+
+You can also load the unpacked extension:
+
+```sh
+npm run build
+```
+
+Then open `chrome://extensions`, enable Developer mode, and select `dist/extension`.
+
+## Safari
+
+1. Install the Safari extension [Userscripts](https://apps.apple.com/us/app/userscripts/id1463298887).
+2. Enable Userscripts in Safari Settings and allow it on `bilibili.com`.
+3. Open the [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) or the [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js).
+4. Install when prompted, then reload the Bilibili video page.
+
+## What It Changes
+
+Bilibili often returns multiple signed media URLs for the same video. Overseas viewers may get routed to hosts like:
+
+```text
+upos-sz-mirrorcosov.bilivideo.com
+xy153x35x231x78xy.mcdn.bilivideo.cn:8082
+```
+
+The script rewrites those slow paths to steadier playback routes, by default:
+
+```text
+upos-sz-mirrorcos.bilivideo.com
+proxy-tf-all-ws.bilivideo.com
+```
+
+Healthy CDN URLs are left alone by default. For stubborn videos, open the `BA` panel, enable `Force all video CDN`, and reload.
+
+## Tested Case
+
+This reported stuttery video:
+
+```text
+https://www.bilibili.com/video/BV1NnVK6cEXs
+```
+
+returned `upos-sz-mirrorcosov.bilivideo.com` playback URLs. The script rewrites them to `upos-sz-mirrorcos.bilivideo.com`.
+
+## Development
+
+```sh
+npm test
+npm run build
+```
+
+Outputs:
+
+```text
+dist/bilibili-accelerator.user.js
+dist/extension/
+```
+
+## Why Star This
+
+If you watch Bilibili overseas, this turns a lot of mysterious buffering into one small, controllable switch.

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,89 +1,63 @@
-# 海外b站，为什么这么慢
+# Bilibili Accelerator：海外 B 站加速
 
-海外看 B 站，冷门视频不该像抽卡一样一会儿流畅、一会儿卡死。
+[English](./README.en.md)
 
-这个小插件会在播放器开始缓冲前，自动改写 Bilibili 返回的慢 CDN 播放地址。它主要处理海外用户常见的卡顿源：`upos-*ov` 海外镜像、MCDN/PCDN 节点，以及某些对你所在网络路由很差的播放 host。
+海外看 B 站，热门视频通常还行，冷门视频却经常一会儿流畅、一会儿卡死。
 
-## 一句话安装
+**Bilibili Accelerator** 是一个用户脚本。它会在播放器开始缓冲前，自动改写 Bilibili 返回的慢 CDN 播放地址，专治海外网络下常见的 `upos-*ov` 海外镜像、MCDN/PCDN 节点和糟糕路由。
 
-装一个用户脚本管理器，然后点安装：
+## 立即安装
 
-- Tampermonkey / Violentmonkey / Userscripts：
-  [安装 GitHub 版](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- GitHub Release：
-  [下载 v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
-- Greasy Fork：
-  [官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+推荐从 Greasy Fork 安装，Chrome、Safari、Firefox、Edge 都可以用。
 
-装好后打开任意 B 站视频，右下角出现 `BA` 按钮，就说明生效了。
+- [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
+- [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
+- [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
+- [GitHub Release v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1)
 
-## Safari 安装
+装好后打开任意 B 站视频。右下角出现 `BA` 按钮，就说明脚本已经生效。
+
+## Chrome / Edge
+
+1. 安装 [Tampermonkey](https://www.tampermonkey.net/) 或 [Violentmonkey](https://violentmonkey.github.io/)。
+2. 打开 [Greasy Fork 脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)。
+3. 点击 Install。
+4. 刷新 B 站视频页。
+
+也可以加载解压扩展：
+
+```sh
+npm run build
+```
+
+然后打开 `chrome://extensions`，开启「开发者模式」，选择 `dist/extension`。
+
+## Safari
 
 1. 安装 Safari 扩展 [Userscripts](https://apps.apple.com/us/app/userscripts/id1463298887)。
 2. 在 Safari 设置里启用 Userscripts，并允许访问 `bilibili.com`。
-3. 打开：
+3. 打开 [Greasy Fork 脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) 或 [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)。
+4. Userscripts 提示安装后，刷新 B 站视频页。
 
-```text
-https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js
-```
+## 它改了什么
 
-4. Userscripts 会提示安装。安装后刷新 B 站视频页。
-
-## Chrome 安装
-
-推荐用 Tampermonkey：
-
-1. 安装 [Tampermonkey](https://www.tampermonkey.net/) 或 [Violentmonkey](https://violentmonkey.github.io/)。
-2. 打开：
-
-   ```text
-   https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js
-   ```
-
-3. Tampermonkey 会弹出安装页，点 Install。
-4. 打开 B 站视频页。
-
-也可以用解压扩展方式：
-
-1. 运行：
-
-   ```sh
-   npm run build
-   ```
-
-2. 打开 Chrome 扩展管理页：
-
-   ```text
-   chrome://extensions
-   ```
-
-3. 开启「开发者模式」。
-4. 点击「加载已解压的扩展程序」。
-5. 选择：
-
-   ```text
-   dist/extension
-   ```
-
-## 它到底改了什么
-
-Bilibili 会给同一个视频返回多条带签名的媒体 URL。海外网络下，冷门视频常被分到这种地址：
+Bilibili 会给同一个视频返回多条带签名的媒体 URL。海外网络下，冷门视频常被分到这些地址：
 
 ```text
 upos-sz-mirrorcosov.bilivideo.com
 xy153x35x231x78xy.mcdn.bilivideo.cn:8082
 ```
 
-插件会把这些慢路径换成更稳的播放路径，默认类似这样：
+脚本会把慢路径换成更稳的播放路径，默认类似：
 
 ```text
 upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-正常 CDN 不会乱动。除非你在 `BA` 面板里打开 `Force all video CDN`。
+正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 `BA`，开启 `Force all video CDN` 后刷新。
 
-## 已测卡顿样本
+## 已测样本
 
 这个视频曾被反馈特别卡：
 
@@ -91,7 +65,7 @@ proxy-tf-all-ws.bilivideo.com
 https://www.bilibili.com/video/BV1NnVK6cEXs
 ```
 
-页面播放数据里返回了 `upos-sz-mirrorcosov.bilivideo.com`。插件会自动改成 `upos-sz-mirrorcos.bilivideo.com`。
+页面播放数据返回了 `upos-sz-mirrorcosov.bilivideo.com`。脚本会自动改成 `upos-sz-mirrorcos.bilivideo.com`。
 
 ## 开发
 
@@ -100,26 +74,13 @@ npm test
 npm run build
 ```
 
-输出文件：
+输出：
 
 ```text
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
 
-## 发布
-
-- GitHub raw 安装源：
-  `https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js`
-- GitHub Release：
-  `https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1`
-- Tampermonkey：
-  打开 GitHub raw 安装源即可触发安装页。
-- Greasy Fork：
-  `https://greasyfork.org/en/scripts/582026-bilibili-accelerator`
-- Greasy Fork 安装源：
-  `https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js`
-
 ## 为什么值得 Star
 
-因为人在海外，看 B 站也应该是在看视频，不是在修网络。
+如果你也在海外看 B 站，这个项目能把很多“玄学卡顿”变成一个可控开关。

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -36,5 +36,6 @@ await writeFile(path.join(extensionDist, "bili-accelerator.page.js"), `${core}\n
 await writeFile(path.join(extensionDist, "content.js"), content);
 await writeFile(path.join(extensionDist, "manifest.json"), manifest);
 await copyFile(path.join(root, "README.md"), path.join(dist, "README.md")).catch(() => {});
+await copyFile(path.join(root, "README.en.md"), path.join(dist, "README.en.md")).catch(() => {});
 
 console.log("Built dist/bilibili-accelerator.user.js and dist/extension");


### PR DESCRIPTION
## Summary
- Polish the Chinese README as the default landing page
- Add an English README with equivalent install and usage guidance
- Copy both README files into dist during build

## Test
- npm test
- npm run build
- node --check dist/bilibili-accelerator.user.js
- node --check dist/extension/content.js
- node --check dist/extension/bili-accelerator.page.js