### PR TITLE
v0.1.3: lightning-only icon + web-fullscreen auto-hide

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,7 +15,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
 - [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
 
-After installation, open any Bilibili video. A small `BA` button in the lower-right corner means the script is active.
+After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
 ## Chrome / Edge
 
@@ -55,7 +55,9 @@ upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-Healthy CDN URLs are left alone by default. For stubborn videos, open the `BA` panel, enable `Force all video CDN`, and reload.
+Healthy CDN URLs are left alone by default. For stubborn videos, open the ⚡ panel, enable `Force all video CDN`, and reload.
+
+In web fullscreen the ⚡ icon fades out so it never covers the video; move the cursor to the lower-right corner to bring it back.
 
 ## Tested Case
 
@@ -80,6 +82,10 @@ Outputs:
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
+
+## Router / Apple TV / Mobile App?
+
+A common request is router-level acceleration so native apps benefit too. See [docs/router-proxy.md](docs/router-proxy.md) for the feasibility and limits: the browser case works, but Apple TV / mobile apps are blocked by custom-CA installation and certificate pinning.
 
 ## Why Star This
 

--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
+- [GitHub Release v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
 - [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
 
-装好后打开任意 B 站视频。右下角出现 `BA` 按钮，就说明脚本已经生效。
+装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
 ## Chrome / Edge
 
@@ -55,7 +55,9 @@ upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 `BA`，开启 `Force all video CDN` 后刷新。
+正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 ⚡ 图标，开启 `Force all video CDN` 后刷新。
+
+网页全屏时 ⚡ 图标会自动淡出，不挡视频；把鼠标移到右下角即可重新唤出。
 
 ## 已测样本
 
@@ -80,6 +82,10 @@ npm run build
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
+
+## 软路由 / Apple TV / 手机 App？
+
+经常有人问能不能放进软路由，让原生 App 也加速。结论和限制见 [docs/router-proxy.md](docs/router-proxy.md)：网页端可行，但 Apple TV / 手机 App 受证书安装与证书固定限制，基本做不到。
 
 ## 为什么值得 Star
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
+- [GitHub Release v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 

--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -15,7 +15,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
 - [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
 
-After installation, open any Bilibili video. A small `BA` button in the lower-right corner means the script is active.
+After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
 ## Chrome / Edge
 
@@ -55,7 +55,9 @@ upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-Healthy CDN URLs are left alone by default. For stubborn videos, open the `BA` panel, enable `Force all video CDN`, and reload.
+Healthy CDN URLs are left alone by default. For stubborn videos, open the ⚡ panel, enable `Force all video CDN`, and reload.
+
+In web fullscreen the ⚡ icon fades out so it never covers the video; move the cursor to the lower-right corner to bring it back.
 
 ## Tested Case
 
@@ -80,6 +82,10 @@ Outputs:
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
+
+## Router / Apple TV / Mobile App?
+
+A common request is router-level acceleration so native apps benefit too. See [docs/router-proxy.md](docs/router-proxy.md) for the feasibility and limits: the browser case works, but Apple TV / mobile apps are blocked by custom-CA installation and certificate pinning.
 
 ## Why Star This
 

--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -13,7 +13,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
+- [GitHub Release v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -15,7 +15,7 @@
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
 - [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
 
-装好后打开任意 B 站视频。右下角出现 `BA` 按钮，就说明脚本已经生效。
+装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
 ## Chrome / Edge
 
@@ -55,7 +55,9 @@ upos-sz-mirrorcos.bilivideo.com
 proxy-tf-all-ws.bilivideo.com
 ```
 
-正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 `BA`，开启 `Force all video CDN` 后刷新。
+正常 CDN 默认不动。遇到特别顽固的视频，可以点右下角 ⚡ 图标，开启 `Force all video CDN` 后刷新。
+
+网页全屏时 ⚡ 图标会自动淡出，不挡视频；把鼠标移到右下角即可重新唤出。
 
 ## 已测样本
 
@@ -80,6 +82,10 @@ npm run build
 dist/bilibili-accelerator.user.js
 dist/extension/
 ```
+
+## 软路由 / Apple TV / 手机 App？
+
+经常有人问能不能放进软路由，让原生 App 也加速。结论和限制见 [docs/router-proxy.md](docs/router-proxy.md)：网页端可行，但 Apple TV / 手机 App 受证书安装与证书固定限制，基本做不到。
 
 ## 为什么值得 Star
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -13,7 +13,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2)
+- [GitHub Release v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -2,7 +2,7 @@
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.1.2
+// @version      0.1.3
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza
@@ -295,7 +295,14 @@
   const STORAGE_KEY = "biliAccelerator.config.v1";
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
+  const IMMERSED_CLASS = "ba-immersed";
+  const REVEAL_HOTZONE = 150;
+  const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
+  let immersive = false;
+  let revealTimer = null;
+  let playerObserver = null;
+  let observedContainer = null;
   const state = {
     rewrites: [],
     rewriteCount: 0,
@@ -503,6 +510,110 @@
       : "Waiting for Bilibili playback URLs.";
   }
 
+  function panelIsOpen() {
+    const host = document.getElementById(BUTTON_ID);
+    return !!(host && host.shadowRoot && host.shadowRoot.querySelector(".ba-panel.open"));
+  }
+
+  function setBadgeHidden(hidden) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (hidden) {
+      host.classList.add(IMMERSED_CLASS);
+    } else {
+      host.classList.remove(IMMERSED_CLASS);
+    }
+  }
+
+  // Show the badge, then fade it back out after a short idle window —
+  // mirrors how the player's own controls behave in fullscreen.
+  function revealBadge() {
+    setBadgeHidden(false);
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+    }
+    revealTimer = setTimeout(function hideAfterIdle() {
+      if (immersive && !panelIsOpen()) {
+        setBadgeHidden(true);
+      }
+    }, REVEAL_TIMEOUT);
+  }
+
+  function setImmersive(next) {
+    if (next === immersive) {
+      return;
+    }
+    immersive = next;
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+      revealTimer = null;
+    }
+    // Hidden by default while immersive so it never covers the video;
+    // restored immediately when leaving web/true fullscreen.
+    setBadgeHidden(immersive && !panelIsOpen());
+  }
+
+  // Bilibili's modern player exposes its layout via data-screen on
+  // .bpx-player-container (normal/wide/web/full/mini). The legacy player
+  // uses a mode-webscreen class. Either signals an immersive layout.
+  function detectScreenMode() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container) {
+      const mode = container.getAttribute("data-screen");
+      if (mode) {
+        return mode;
+      }
+    }
+    if (document.querySelector(".mode-webscreen")) {
+      return "web";
+    }
+    return "normal";
+  }
+
+  function refreshImmersive() {
+    const mode = detectScreenMode();
+    setImmersive(mode === "web" || mode === "full");
+  }
+
+  function ensurePlayerObserver() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container && container !== observedContainer) {
+      if (playerObserver) {
+        playerObserver.disconnect();
+      }
+      observedContainer = container;
+      playerObserver = new MutationObserver(refreshImmersive);
+      playerObserver.observe(container, {
+        attributes: true,
+        attributeFilter: ["data-screen", "class"]
+      });
+    }
+    refreshImmersive();
+  }
+
+  function handlePointerMove(event) {
+    if (!immersive) {
+      return;
+    }
+    const nearRight = (root.innerWidth - event.clientX) < REVEAL_HOTZONE;
+    const nearBottom = (root.innerHeight - event.clientY) < REVEAL_HOTZONE;
+    if (nearRight && nearBottom) {
+      revealBadge();
+    }
+  }
+
+  function installImmersiveWatch() {
+    document.addEventListener("mousemove", handlePointerMove, { passive: true });
+    document.addEventListener("fullscreenchange", refreshImmersive);
+    document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    // The player mounts after this script runs and is recreated on SPA
+    // navigation, so keep re-binding the observer to the live container.
+    ensurePlayerObserver();
+    setInterval(ensurePlayerObserver, 1500);
+  }
+
   function installUi() {
     if (!document.documentElement || document.getElementById(BUTTON_ID)) {
       return;
@@ -513,15 +624,14 @@
     const shadow = host.attachShadow({ mode: "open" });
     const style = document.createElement("style");
     style.textContent = [
-      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a}",
+      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
+      ":host(.ba-immersed){opacity:0;pointer-events:none}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
-      ".ba-toggle{display:inline-flex;align-items:center;gap:7px;height:36px;min-width:72px;border:1px solid rgba(23,32,42,.14);border-radius:999px;background:rgba(255,255,255,.92);color:#17202a;box-shadow:0 8px 24px rgba(21,32,43,.18),0 1px 0 rgba(255,255,255,.9) inset;backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px);cursor:pointer;font-weight:700;padding:0 12px 0 9px;transition:transform .16s ease,box-shadow .16s ease,background .16s ease}",
-      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 30px rgba(21,32,43,.22),0 1px 0 rgba(255,255,255,.9) inset;background:#fff}",
+      ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",
+      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(0,174,236,.5),0 1px 0 rgba(255,255,255,.45) inset}",
       ".ba-toggle:active{transform:translateY(0)}",
-      ".ba-mark{display:grid;place-items:center;width:22px;height:22px;border-radius:999px;background:#00aeec;color:#fff;box-shadow:0 4px 10px rgba(0,174,236,.34)}",
-      ".ba-mark svg{width:14px;height:14px;display:block}",
-      ".ba-toggle-text{font-size:12px;letter-spacing:0}",
+      ".ba-toggle svg{width:20px;height:20px;display:block;filter:drop-shadow(0 1px 1px rgba(0,80,110,.35))}",
       ".ba-panel{display:none;position:absolute;right:0;bottom:48px;width:min(340px,calc(100vw - 36px));padding:14px;border:1px solid rgba(23,32,42,.12);border-radius:12px;background:rgba(255,255,255,.96);box-shadow:0 18px 46px rgba(21,32,43,.24);backdrop-filter:saturate(180%) blur(18px);-webkit-backdrop-filter:saturate(180%) blur(18px)}",
       ".ba-panel.open{display:block}",
       ".ba-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px}",
@@ -557,14 +667,13 @@
     toggle.className = "ba-toggle";
     toggle.type = "button";
     toggle.title = "Bilibili Accelerator";
-    const mark = document.createElement("span");
-    mark.className = "ba-mark";
-    mark.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
-    const toggleText = document.createElement("span");
-    toggleText.className = "ba-toggle-text";
-    toggleText.textContent = "Bili";
-    toggle.appendChild(mark);
-    toggle.appendChild(toggleText);
+    toggle.setAttribute("aria-label", "Bilibili Accelerator");
+    toggle.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
+    toggle.addEventListener("mouseenter", function handleToggleEnter() {
+      if (immersive) {
+        revealBadge();
+      }
+    });
 
     const panel = document.createElement("section");
     panel.className = "ba-panel";
@@ -709,6 +818,9 @@
     close.textContent = "Close";
     close.addEventListener("click", function handleClose() {
       panel.classList.remove("open");
+      if (immersive) {
+        revealBadge();
+      }
     });
 
     const actions = document.createElement("div");
@@ -730,6 +842,9 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
+      if (immersive && !panel.classList.contains("open")) {
+        revealBadge();
+      }
     });
 
     shadow.appendChild(style);
@@ -760,10 +875,15 @@
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", installUi, { once: true });
-  } else {
+  function bootstrapUi() {
     installUi();
+    installImmersiveWatch();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapUi, { once: true });
+  } else {
+    bootstrapUi();
   }
 
   console.info("[BiliAccelerator] installed", root.BiliAccelerator.getConfig());

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -813,15 +813,20 @@
       root.location.reload();
     });
 
-    const close = document.createElement("button");
-    close.type = "button";
-    close.textContent = "Close";
-    close.addEventListener("click", function handleClose() {
+    function closePanel() {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
       panel.classList.remove("open");
       if (immersive) {
         revealBadge();
       }
-    });
+    }
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.textContent = "Close";
+    close.addEventListener("click", closePanel);
 
     const actions = document.createElement("div");
     actions.className = "ba-actions";
@@ -855,6 +860,19 @@
       } else {
         revealBadge();
       }
+    });
+
+    // Click anywhere outside the control closes the panel. Clicks inside
+    // the shadow DOM keep `host` in the composed path, so they're ignored.
+    document.addEventListener("click", function handleOutsideClick(event) {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
+      const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+      if (path.indexOf(host) !== -1 || event.target === host) {
+        return;
+      }
+      closePanel();
     });
 
     shadow.appendChild(style);

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -296,6 +296,7 @@
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
   const IMMERSED_CLASS = "ba-immersed";
+  const LIFTED_CLASS = "ba-lifted";
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
@@ -572,8 +573,23 @@
     return "normal";
   }
 
+  function setLifted(lifted) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (lifted) {
+      host.classList.add(LIFTED_CLASS);
+    } else {
+      host.classList.remove(LIFTED_CLASS);
+    }
+  }
+
   function refreshImmersive() {
     const mode = detectScreenMode();
+    // Lift above the control bar whenever the player fills the viewport
+    // width (web/full/wide). Hide-by-default only for fullscreen layouts.
+    setLifted(mode === "web" || mode === "full" || mode === "wide");
     setImmersive(mode === "web" || mode === "full");
   }
 
@@ -626,6 +642,9 @@
     style.textContent = [
       ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
       ":host(.ba-immersed){opacity:0;pointer-events:none}",
+      // Enlarged player modes put their control bar along the viewport
+      // bottom; lift the badge above it so it never covers the 全屏 button.
+      ":host(.ba-lifted){bottom:84px}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
       ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -842,7 +842,17 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
-      if (immersive && !panel.classList.contains("open")) {
+      if (!immersive) {
+        return;
+      }
+      if (panel.classList.contains("open")) {
+        // Pin the badge open while the settings panel is showing.
+        if (revealTimer) {
+          clearTimeout(revealTimer);
+          revealTimer = null;
+        }
+        setBadgeHidden(false);
+      } else {
         revealBadge();
       }
     });

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -278,7 +278,14 @@
   const STORAGE_KEY = "biliAccelerator.config.v1";
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
+  const IMMERSED_CLASS = "ba-immersed";
+  const REVEAL_HOTZONE = 150;
+  const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
+  let immersive = false;
+  let revealTimer = null;
+  let playerObserver = null;
+  let observedContainer = null;
   const state = {
     rewrites: [],
     rewriteCount: 0,
@@ -486,6 +493,110 @@
       : "Waiting for Bilibili playback URLs.";
   }
 
+  function panelIsOpen() {
+    const host = document.getElementById(BUTTON_ID);
+    return !!(host && host.shadowRoot && host.shadowRoot.querySelector(".ba-panel.open"));
+  }
+
+  function setBadgeHidden(hidden) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (hidden) {
+      host.classList.add(IMMERSED_CLASS);
+    } else {
+      host.classList.remove(IMMERSED_CLASS);
+    }
+  }
+
+  // Show the badge, then fade it back out after a short idle window —
+  // mirrors how the player's own controls behave in fullscreen.
+  function revealBadge() {
+    setBadgeHidden(false);
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+    }
+    revealTimer = setTimeout(function hideAfterIdle() {
+      if (immersive && !panelIsOpen()) {
+        setBadgeHidden(true);
+      }
+    }, REVEAL_TIMEOUT);
+  }
+
+  function setImmersive(next) {
+    if (next === immersive) {
+      return;
+    }
+    immersive = next;
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+      revealTimer = null;
+    }
+    // Hidden by default while immersive so it never covers the video;
+    // restored immediately when leaving web/true fullscreen.
+    setBadgeHidden(immersive && !panelIsOpen());
+  }
+
+  // Bilibili's modern player exposes its layout via data-screen on
+  // .bpx-player-container (normal/wide/web/full/mini). The legacy player
+  // uses a mode-webscreen class. Either signals an immersive layout.
+  function detectScreenMode() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container) {
+      const mode = container.getAttribute("data-screen");
+      if (mode) {
+        return mode;
+      }
+    }
+    if (document.querySelector(".mode-webscreen")) {
+      return "web";
+    }
+    return "normal";
+  }
+
+  function refreshImmersive() {
+    const mode = detectScreenMode();
+    setImmersive(mode === "web" || mode === "full");
+  }
+
+  function ensurePlayerObserver() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container && container !== observedContainer) {
+      if (playerObserver) {
+        playerObserver.disconnect();
+      }
+      observedContainer = container;
+      playerObserver = new MutationObserver(refreshImmersive);
+      playerObserver.observe(container, {
+        attributes: true,
+        attributeFilter: ["data-screen", "class"]
+      });
+    }
+    refreshImmersive();
+  }
+
+  function handlePointerMove(event) {
+    if (!immersive) {
+      return;
+    }
+    const nearRight = (root.innerWidth - event.clientX) < REVEAL_HOTZONE;
+    const nearBottom = (root.innerHeight - event.clientY) < REVEAL_HOTZONE;
+    if (nearRight && nearBottom) {
+      revealBadge();
+    }
+  }
+
+  function installImmersiveWatch() {
+    document.addEventListener("mousemove", handlePointerMove, { passive: true });
+    document.addEventListener("fullscreenchange", refreshImmersive);
+    document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    // The player mounts after this script runs and is recreated on SPA
+    // navigation, so keep re-binding the observer to the live container.
+    ensurePlayerObserver();
+    setInterval(ensurePlayerObserver, 1500);
+  }
+
   function installUi() {
     if (!document.documentElement || document.getElementById(BUTTON_ID)) {
       return;
@@ -496,15 +607,14 @@
     const shadow = host.attachShadow({ mode: "open" });
     const style = document.createElement("style");
     style.textContent = [
-      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a}",
+      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
+      ":host(.ba-immersed){opacity:0;pointer-events:none}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
-      ".ba-toggle{display:inline-flex;align-items:center;gap:7px;height:36px;min-width:72px;border:1px solid rgba(23,32,42,.14);border-radius:999px;background:rgba(255,255,255,.92);color:#17202a;box-shadow:0 8px 24px rgba(21,32,43,.18),0 1px 0 rgba(255,255,255,.9) inset;backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px);cursor:pointer;font-weight:700;padding:0 12px 0 9px;transition:transform .16s ease,box-shadow .16s ease,background .16s ease}",
-      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 30px rgba(21,32,43,.22),0 1px 0 rgba(255,255,255,.9) inset;background:#fff}",
+      ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",
+      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(0,174,236,.5),0 1px 0 rgba(255,255,255,.45) inset}",
       ".ba-toggle:active{transform:translateY(0)}",
-      ".ba-mark{display:grid;place-items:center;width:22px;height:22px;border-radius:999px;background:#00aeec;color:#fff;box-shadow:0 4px 10px rgba(0,174,236,.34)}",
-      ".ba-mark svg{width:14px;height:14px;display:block}",
-      ".ba-toggle-text{font-size:12px;letter-spacing:0}",
+      ".ba-toggle svg{width:20px;height:20px;display:block;filter:drop-shadow(0 1px 1px rgba(0,80,110,.35))}",
       ".ba-panel{display:none;position:absolute;right:0;bottom:48px;width:min(340px,calc(100vw - 36px));padding:14px;border:1px solid rgba(23,32,42,.12);border-radius:12px;background:rgba(255,255,255,.96);box-shadow:0 18px 46px rgba(21,32,43,.24);backdrop-filter:saturate(180%) blur(18px);-webkit-backdrop-filter:saturate(180%) blur(18px)}",
       ".ba-panel.open{display:block}",
       ".ba-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px}",
@@ -540,14 +650,13 @@
     toggle.className = "ba-toggle";
     toggle.type = "button";
     toggle.title = "Bilibili Accelerator";
-    const mark = document.createElement("span");
-    mark.className = "ba-mark";
-    mark.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
-    const toggleText = document.createElement("span");
-    toggleText.className = "ba-toggle-text";
-    toggleText.textContent = "Bili";
-    toggle.appendChild(mark);
-    toggle.appendChild(toggleText);
+    toggle.setAttribute("aria-label", "Bilibili Accelerator");
+    toggle.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
+    toggle.addEventListener("mouseenter", function handleToggleEnter() {
+      if (immersive) {
+        revealBadge();
+      }
+    });
 
     const panel = document.createElement("section");
     panel.className = "ba-panel";
@@ -692,6 +801,9 @@
     close.textContent = "Close";
     close.addEventListener("click", function handleClose() {
       panel.classList.remove("open");
+      if (immersive) {
+        revealBadge();
+      }
     });
 
     const actions = document.createElement("div");
@@ -713,6 +825,9 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
+      if (immersive && !panel.classList.contains("open")) {
+        revealBadge();
+      }
     });
 
     shadow.appendChild(style);
@@ -743,10 +858,15 @@
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", installUi, { once: true });
-  } else {
+  function bootstrapUi() {
     installUi();
+    installImmersiveWatch();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapUi, { once: true });
+  } else {
+    bootstrapUi();
   }
 
   console.info("[BiliAccelerator] installed", root.BiliAccelerator.getConfig());

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -279,6 +279,7 @@
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
   const IMMERSED_CLASS = "ba-immersed";
+  const LIFTED_CLASS = "ba-lifted";
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
@@ -555,8 +556,23 @@
     return "normal";
   }
 
+  function setLifted(lifted) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (lifted) {
+      host.classList.add(LIFTED_CLASS);
+    } else {
+      host.classList.remove(LIFTED_CLASS);
+    }
+  }
+
   function refreshImmersive() {
     const mode = detectScreenMode();
+    // Lift above the control bar whenever the player fills the viewport
+    // width (web/full/wide). Hide-by-default only for fullscreen layouts.
+    setLifted(mode === "web" || mode === "full" || mode === "wide");
     setImmersive(mode === "web" || mode === "full");
   }
 
@@ -609,6 +625,9 @@
     style.textContent = [
       ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
       ":host(.ba-immersed){opacity:0;pointer-events:none}",
+      // Enlarged player modes put their control bar along the viewport
+      // bottom; lift the badge above it so it never covers the 全屏 button.
+      ":host(.ba-lifted){bottom:84px}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
       ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -825,7 +825,17 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
-      if (immersive && !panel.classList.contains("open")) {
+      if (!immersive) {
+        return;
+      }
+      if (panel.classList.contains("open")) {
+        // Pin the badge open while the settings panel is showing.
+        if (revealTimer) {
+          clearTimeout(revealTimer);
+          revealTimer = null;
+        }
+        setBadgeHidden(false);
+      } else {
         revealBadge();
       }
     });

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -796,15 +796,20 @@
       root.location.reload();
     });
 
-    const close = document.createElement("button");
-    close.type = "button";
-    close.textContent = "Close";
-    close.addEventListener("click", function handleClose() {
+    function closePanel() {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
       panel.classList.remove("open");
       if (immersive) {
         revealBadge();
       }
-    });
+    }
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.textContent = "Close";
+    close.addEventListener("click", closePanel);
 
     const actions = document.createElement("div");
     actions.className = "ba-actions";
@@ -838,6 +843,19 @@
       } else {
         revealBadge();
       }
+    });
+
+    // Click anywhere outside the control closes the panel. Clicks inside
+    // the shadow DOM keep `host` in the composed path, so they're ignored.
+    document.addEventListener("click", function handleOutsideClick(event) {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
+      const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+      if (path.indexOf(host) !== -1 || event.target === host) {
+        return;
+      }
+      closePanel();
     });
 
     shadow.appendChild(style);

--- a/dist/extension/manifest.json
+++ b/dist/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Rewrites slow Bilibili playback CDN URLs before Safari starts buffering.",
   "icons": {},
   "content_scripts": [

--- a/docs/router-proxy.md
+++ b/docs/router-proxy.md
@@ -1,0 +1,51 @@
+# 软路由 / Apple TV / 手机 App 加速：可行性说明
+
+> Router-level acceleration for native apps — feasibility notes.
+
+很多用户问：能不能把这个加速能力放进软路由，让 **Apple TV、手机 B 站 App** 上看视频也受益？
+
+简短回答：**网页端可以，原生 App 基本不行。** 下面说明原因，方便有动手能力的用户自己评估。
+
+## 这个脚本是怎么工作的
+
+脚本运行在 `bilibili.com` 网页里，劫持页面的 `JSON.parse` / `fetch`，在播放器开始缓冲**之前**把返回的慢 CDN 播放地址改掉（见 [`src/core/rewrite.js`](../src/core/rewrite.js)）。
+
+关键点：它依赖「能在页面里注入 JavaScript」。Apple TV、手机原生 App 不跑我们的 JS，所以唯一能帮它们的办法是**在网络层改写**——也就是在路由器上做透明代理，拦截播放 API 的 HTTPS 响应，套用同样的改写逻辑。
+
+## 难点
+
+1. **HTTPS MITM（中间人）**
+   播放接口是 HTTPS。要在路由器上读取并改写响应体，必须做 MITM，并在**每一台设备**上安装自签根证书。
+   - Apple TV 安装并信任自定义根证书非常麻烦（没有简单入口）。
+   - 手机端虽然能装证书，但仍有第 2 点。
+
+2. **证书固定（Certificate Pinning）**
+   B 站原生 App 很可能对自家域名做了证书固定。一旦固定，即使装了根证书，MITM 也会被 App 拒绝，改写**无法生效**。网页（浏览器）不做这种固定，所以网页端可行。
+
+3. **这是另一个产品**
+   路由器方案是一套 OpenWrt / sing-box / mitmproxy 插件，和用户脚本是两条独立的工程路线，维护成本完全不同。
+
+## 现实的结论
+
+| 场景 | 可行性 |
+| --- | --- |
+| 路由器后面用**浏览器**看 B 站（电脑 / 平板 Safari、Chrome） | ✅ 可行，但直接装本脚本更简单，无需路由器 |
+| Apple TV B 站 App | ❌ 证书安装困难 + 大概率证书固定 |
+| 手机 B 站 App | ⚠️ 需自装根证书；若 App 做了证书固定则无效 |
+
+好消息是 [`src/core/rewrite.js`](../src/core/rewrite.js) 是**纯函数、可复用**的：如果有人想在 OpenWrt 上用 mitmproxy 给网页端做改写，可以直接复用这套规则。但因为上面的限制，我们不会把它做进用户脚本的发布里，也不承诺「Apple TV 开箱即用」。
+
+如果你在这方面有实战经验（尤其是绕过/确认 B 站 App 证书固定的情况），欢迎来 [Issues](https://github.com/realzza/bilibili-accelerator/issues) 讨论。
+
+---
+
+## English summary
+
+The script works by injecting JS into the `bilibili.com` page and rewriting the playback CDN URLs before buffering. Native apps (Apple TV, mobile B站 app) don't run our JS, so the only path is **router-level HTTPS MITM** that rewrites the playurl API response.
+
+That runs into two hard walls:
+
+1. **HTTPS MITM needs a custom root CA installed on every device** — painful on Apple TV.
+2. **The native app likely uses certificate pinning**, which defeats MITM even with the CA installed. Browsers don't pin, which is why the web case works.
+
+So: browser-behind-a-router is doable (but just installing the userscript is simpler), while the Apple TV / mobile-app case is not something we can ship reliably. The core rewrite logic in [`src/core/rewrite.js`](../src/core/rewrite.js) is pure and reusable for anyone who wants to build a mitmproxy rule set for the web case. Experiences with the app's pinning are welcome in the issue tracker.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-accelerator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Safari-friendly Bilibili playback CDN accelerator.",
   "scripts": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -14,7 +14,7 @@ const userscriptHeader = `// ==UserScript==
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.1.2
+// @version      0.1.3
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Rewrites slow Bilibili playback CDN URLs before Safari starts buffering.",
   "icons": {},
   "content_scripts": [

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -11,6 +11,7 @@
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
   const IMMERSED_CLASS = "ba-immersed";
+  const LIFTED_CLASS = "ba-lifted";
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
@@ -287,8 +288,23 @@
     return "normal";
   }
 
+  function setLifted(lifted) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (lifted) {
+      host.classList.add(LIFTED_CLASS);
+    } else {
+      host.classList.remove(LIFTED_CLASS);
+    }
+  }
+
   function refreshImmersive() {
     const mode = detectScreenMode();
+    // Lift above the control bar whenever the player fills the viewport
+    // width (web/full/wide). Hide-by-default only for fullscreen layouts.
+    setLifted(mode === "web" || mode === "full" || mode === "wide");
     setImmersive(mode === "web" || mode === "full");
   }
 
@@ -341,6 +357,9 @@
     style.textContent = [
       ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
       ":host(.ba-immersed){opacity:0;pointer-events:none}",
+      // Enlarged player modes put their control bar along the viewport
+      // bottom; lift the badge above it so it never covers the 全屏 button.
+      ":host(.ba-lifted){bottom:84px}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
       ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -10,7 +10,14 @@
   const STORAGE_KEY = "biliAccelerator.config.v1";
   const PANEL_ID = "bili-accelerator-panel";
   const BUTTON_ID = "bili-accelerator-button";
+  const IMMERSED_CLASS = "ba-immersed";
+  const REVEAL_HOTZONE = 150;
+  const REVEAL_TIMEOUT = 2600;
   const nativeJsonParse = JSON.parse;
+  let immersive = false;
+  let revealTimer = null;
+  let playerObserver = null;
+  let observedContainer = null;
   const state = {
     rewrites: [],
     rewriteCount: 0,
@@ -218,6 +225,110 @@
       : "Waiting for Bilibili playback URLs.";
   }
 
+  function panelIsOpen() {
+    const host = document.getElementById(BUTTON_ID);
+    return !!(host && host.shadowRoot && host.shadowRoot.querySelector(".ba-panel.open"));
+  }
+
+  function setBadgeHidden(hidden) {
+    const host = document.getElementById(BUTTON_ID);
+    if (!host) {
+      return;
+    }
+    if (hidden) {
+      host.classList.add(IMMERSED_CLASS);
+    } else {
+      host.classList.remove(IMMERSED_CLASS);
+    }
+  }
+
+  // Show the badge, then fade it back out after a short idle window —
+  // mirrors how the player's own controls behave in fullscreen.
+  function revealBadge() {
+    setBadgeHidden(false);
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+    }
+    revealTimer = setTimeout(function hideAfterIdle() {
+      if (immersive && !panelIsOpen()) {
+        setBadgeHidden(true);
+      }
+    }, REVEAL_TIMEOUT);
+  }
+
+  function setImmersive(next) {
+    if (next === immersive) {
+      return;
+    }
+    immersive = next;
+    if (revealTimer) {
+      clearTimeout(revealTimer);
+      revealTimer = null;
+    }
+    // Hidden by default while immersive so it never covers the video;
+    // restored immediately when leaving web/true fullscreen.
+    setBadgeHidden(immersive && !panelIsOpen());
+  }
+
+  // Bilibili's modern player exposes its layout via data-screen on
+  // .bpx-player-container (normal/wide/web/full/mini). The legacy player
+  // uses a mode-webscreen class. Either signals an immersive layout.
+  function detectScreenMode() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container) {
+      const mode = container.getAttribute("data-screen");
+      if (mode) {
+        return mode;
+      }
+    }
+    if (document.querySelector(".mode-webscreen")) {
+      return "web";
+    }
+    return "normal";
+  }
+
+  function refreshImmersive() {
+    const mode = detectScreenMode();
+    setImmersive(mode === "web" || mode === "full");
+  }
+
+  function ensurePlayerObserver() {
+    const container = document.querySelector(".bpx-player-container");
+    if (container && container !== observedContainer) {
+      if (playerObserver) {
+        playerObserver.disconnect();
+      }
+      observedContainer = container;
+      playerObserver = new MutationObserver(refreshImmersive);
+      playerObserver.observe(container, {
+        attributes: true,
+        attributeFilter: ["data-screen", "class"]
+      });
+    }
+    refreshImmersive();
+  }
+
+  function handlePointerMove(event) {
+    if (!immersive) {
+      return;
+    }
+    const nearRight = (root.innerWidth - event.clientX) < REVEAL_HOTZONE;
+    const nearBottom = (root.innerHeight - event.clientY) < REVEAL_HOTZONE;
+    if (nearRight && nearBottom) {
+      revealBadge();
+    }
+  }
+
+  function installImmersiveWatch() {
+    document.addEventListener("mousemove", handlePointerMove, { passive: true });
+    document.addEventListener("fullscreenchange", refreshImmersive);
+    document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    // The player mounts after this script runs and is recreated on SPA
+    // navigation, so keep re-binding the observer to the live container.
+    ensurePlayerObserver();
+    setInterval(ensurePlayerObserver, 1500);
+  }
+
   function installUi() {
     if (!document.documentElement || document.getElementById(BUTTON_ID)) {
       return;
@@ -228,15 +339,14 @@
     const shadow = host.attachShadow({ mode: "open" });
     const style = document.createElement("style");
     style.textContent = [
-      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a}",
+      ":host{position:fixed;right:18px;bottom:18px;z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#17202a;transition:opacity .25s ease}",
+      ":host(.ba-immersed){opacity:0;pointer-events:none}",
       "*{box-sizing:border-box}",
       "button,input,select{font:inherit}",
-      ".ba-toggle{display:inline-flex;align-items:center;gap:7px;height:36px;min-width:72px;border:1px solid rgba(23,32,42,.14);border-radius:999px;background:rgba(255,255,255,.92);color:#17202a;box-shadow:0 8px 24px rgba(21,32,43,.18),0 1px 0 rgba(255,255,255,.9) inset;backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px);cursor:pointer;font-weight:700;padding:0 12px 0 9px;transition:transform .16s ease,box-shadow .16s ease,background .16s ease}",
-      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 30px rgba(21,32,43,.22),0 1px 0 rgba(255,255,255,.9) inset;background:#fff}",
+      ".ba-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid rgba(255,255,255,.4);border-radius:50%;background:linear-gradient(135deg,#00b5f5,#0091cc);color:#fff;box-shadow:0 8px 22px rgba(0,174,236,.42),0 1px 0 rgba(255,255,255,.45) inset;cursor:pointer;padding:0;transition:transform .16s ease,box-shadow .16s ease}",
+      ".ba-toggle:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(0,174,236,.5),0 1px 0 rgba(255,255,255,.45) inset}",
       ".ba-toggle:active{transform:translateY(0)}",
-      ".ba-mark{display:grid;place-items:center;width:22px;height:22px;border-radius:999px;background:#00aeec;color:#fff;box-shadow:0 4px 10px rgba(0,174,236,.34)}",
-      ".ba-mark svg{width:14px;height:14px;display:block}",
-      ".ba-toggle-text{font-size:12px;letter-spacing:0}",
+      ".ba-toggle svg{width:20px;height:20px;display:block;filter:drop-shadow(0 1px 1px rgba(0,80,110,.35))}",
       ".ba-panel{display:none;position:absolute;right:0;bottom:48px;width:min(340px,calc(100vw - 36px));padding:14px;border:1px solid rgba(23,32,42,.12);border-radius:12px;background:rgba(255,255,255,.96);box-shadow:0 18px 46px rgba(21,32,43,.24);backdrop-filter:saturate(180%) blur(18px);-webkit-backdrop-filter:saturate(180%) blur(18px)}",
       ".ba-panel.open{display:block}",
       ".ba-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px}",
@@ -272,14 +382,13 @@
     toggle.className = "ba-toggle";
     toggle.type = "button";
     toggle.title = "Bilibili Accelerator";
-    const mark = document.createElement("span");
-    mark.className = "ba-mark";
-    mark.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
-    const toggleText = document.createElement("span");
-    toggleText.className = "ba-toggle-text";
-    toggleText.textContent = "Bili";
-    toggle.appendChild(mark);
-    toggle.appendChild(toggleText);
+    toggle.setAttribute("aria-label", "Bilibili Accelerator");
+    toggle.innerHTML = "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M13 2 4 14h7l-1 8 10-13h-7l1-7Z\"/></svg>";
+    toggle.addEventListener("mouseenter", function handleToggleEnter() {
+      if (immersive) {
+        revealBadge();
+      }
+    });
 
     const panel = document.createElement("section");
     panel.className = "ba-panel";
@@ -424,6 +533,9 @@
     close.textContent = "Close";
     close.addEventListener("click", function handleClose() {
       panel.classList.remove("open");
+      if (immersive) {
+        revealBadge();
+      }
     });
 
     const actions = document.createElement("div");
@@ -445,6 +557,9 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
+      if (immersive && !panel.classList.contains("open")) {
+        revealBadge();
+      }
     });
 
     shadow.appendChild(style);
@@ -475,10 +590,15 @@
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", installUi, { once: true });
-  } else {
+  function bootstrapUi() {
     installUi();
+    installImmersiveWatch();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrapUi, { once: true });
+  } else {
+    bootstrapUi();
   }
 
   console.info("[BiliAccelerator] installed", root.BiliAccelerator.getConfig());

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -528,15 +528,20 @@
       root.location.reload();
     });
 
-    const close = document.createElement("button");
-    close.type = "button";
-    close.textContent = "Close";
-    close.addEventListener("click", function handleClose() {
+    function closePanel() {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
       panel.classList.remove("open");
       if (immersive) {
         revealBadge();
       }
-    });
+    }
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.textContent = "Close";
+    close.addEventListener("click", closePanel);
 
     const actions = document.createElement("div");
     actions.className = "ba-actions";
@@ -570,6 +575,19 @@
       } else {
         revealBadge();
       }
+    });
+
+    // Click anywhere outside the control closes the panel. Clicks inside
+    // the shadow DOM keep `host` in the composed path, so they're ignored.
+    document.addEventListener("click", function handleOutsideClick(event) {
+      if (!panel.classList.contains("open")) {
+        return;
+      }
+      const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+      if (path.indexOf(host) !== -1 || event.target === host) {
+        return;
+      }
+      closePanel();
     });
 
     shadow.appendChild(style);

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -557,7 +557,17 @@
     toggle.addEventListener("click", function handleToggle() {
       panel.classList.toggle("open");
       renderStatus();
-      if (immersive && !panel.classList.contains("open")) {
+      if (!immersive) {
+        return;
+      }
+      if (panel.classList.contains("open")) {
+        // Pin the badge open while the settings panel is showing.
+        if (revealTimer) {
+          clearTimeout(revealTimer);
+          revealTimer = null;
+        }
+        setBadgeHidden(false);
+      } else {
         revealBadge();
       }
     });


### PR DESCRIPTION
Next-release changes from open-source user feedback. **Draft — for testing, do not merge yet.**

## Changes
1. **Icon — lightning only.** Dropped the `Bili` text label; the floating control is now a compact round ⚡ badge that covers less of the video. (`src/page/bili-accelerator.page.js`)
2. **Web-fullscreen UX (深度优化).** Previously the badge only vanished in *true* fullscreen — that's free browser behavior (non-fullscreen-subtree nodes aren't rendered). **Web fullscreen** is CSS-only, so the badge stayed on top and covered the bottom-right of the video. Now we detect the player layout via `data-screen` on `.bpx-player-container` (with a legacy `mode-webscreen` fallback) and **auto-hide** the badge in web/true fullscreen. Moving the cursor into the **bottom-right hot corner** fades it back in; it hides again after a short idle window, mirroring how the player's own controls behave. Opening the panel keeps it pinned.
3. **Router / Apple TV / mobile app.** Documented feasibility + limits (HTTPS MITM needs a custom root CA per device; the native app likely uses cert pinning, which defeats it) in [`docs/router-proxy.md`](docs/router-proxy.md) rather than shipping it into the userscript.
4. Version bump `0.1.2 → 0.1.3`; READMEs refreshed (`BA` → ⚡, fullscreen note).

## Test plan
- `npm test` (9 passing) + `npm run build` ✅
- Manual on a real Bilibili video:
  - Normal mode: ⚡ badge visible bottom-right; panel opens/saves/reloads.
  - **网页全屏**: badge fades out, no longer covers the video; cursor → bottom-right corner brings it back; idles away after ~2.6s; opening the panel keeps it visible.
  - **True fullscreen**: badge absent (unchanged).
  - SPA navigation between videos: behavior still correct after switching videos.
  - Sanity: rewrites still fire (rewrite count increments) on a known slow video, e.g. `BV1NnVK6cEXs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)