### PR TITLE
Smooth the speed meter: active throughput + elastic window (0.2.2)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1)
+- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
@@ -74,7 +74,7 @@ In web fullscreen the ⚡ icon fades out so it never covers the video; move the 
 - **Plain-language panel** — one status (Playing smoothly / Finding a faster server), one switch, one "Boost harder" button. Every old knob still lives under **Advanced settings**.
 - **Optional bandwidth guard** — stop Bilibili from using your upload via WebRTC P2P (off by default).
 - **Toolbar popup + synced settings** for the browser extension.
-- **Live speed graph** *(0.2.1)* — a real-time download-speed chart right in the panel, with a buffer-health fallback when a CDN hides byte sizes.
+- **Live speed graph** *(0.2.1, refined in 0.2.2)* — a real-time download-speed chart right in the panel. It measures throughput over the time data is actually flowing, so a fast link reads high and steady instead of flickering to zero between buffer fills. Falls back to buffer health when a CDN hides byte sizes.
 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="Advanced settings: auto server selection, hidden-PCDN detection, live auto-recover, bandwidth guard" width="360">

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1)
+- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
@@ -74,7 +74,7 @@ proxy-tf-all-ws.bilivideo.com
 - **大白话面板**：一个状态（流畅播放 / 正在找更快的服务器）、一个开关、一个「再加把劲」按钮。所有老选项都收进 **Advanced settings（高级设置）**。
 - **可选的带宽保护**：阻止 B 站通过 WebRTC P2P 占用你的上传带宽（默认关闭）。
 - **浏览器扩展新增工具栏弹窗与设置同步。**
-- **实时速度图** *(0.2.1)*：面板内置实时下载速度曲线，当 CDN 不暴露字节数时自动回退为缓冲时长。
+- **实时速度图** *(0.2.1，0.2.2 优化)*：面板内置实时下载速度曲线。速度按真正在传输数据的时段来计算，因此快网络会稳定显示高速，而不会在缓冲填满的间隙频繁掉到 0；当 CDN 不暴露字节数时自动回退为缓冲时长。
 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="高级设置：自动选最快服务器、隐藏 PCDN 识别、卡顿自动恢复、带宽保护" width="360">

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -2,7 +2,7 @@
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.2.1
+// @version      0.2.2
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza
@@ -326,6 +326,63 @@
     return (bytes * 8 / 1e6) / (durationMs / 1000);
   }
 
+  // Total length of a set of [start, end] intervals with overlaps merged, so
+  // two segments downloaded in parallel count their shared time only once.
+  function unionDurationMs(intervals) {
+    if (!intervals || !intervals.length) {
+      return 0;
+    }
+    const sorted = intervals.slice().sort(function byStart(a, b) {
+      return a[0] - b[0];
+    });
+    let total = 0;
+    let curStart = sorted[0][0];
+    let curEnd = sorted[0][1];
+    for (let i = 1; i < sorted.length; i += 1) {
+      const s = sorted[i][0];
+      const e = sorted[i][1];
+      if (s > curEnd) {
+        total += curEnd - curStart;
+        curStart = s;
+        curEnd = e;
+      } else if (e > curEnd) {
+        curEnd = e;
+      }
+    }
+    total += curEnd - curStart;
+    return total;
+  }
+
+  // Aggregate "active" throughput: bytes moved per second of time actually spent
+  // transferring, measured over the trailing `windowMs`. Unlike dividing by
+  // wall-clock, idle gaps between the player's burst downloads don't drag the
+  // rate to zero — this reflects the link's real capacity. Bytes from transfers
+  // straddling the window edge are prorated to the in-window fraction, and the
+  // active time is the union of all transfer intervals (parallel video+audio
+  // segments count their overlap once). transfers: [{ start, end, bytes }] in ms.
+  function aggregateThroughput(transfers, now, windowMs) {
+    if (!transfers || !transfers.length || !(windowMs > 0)) {
+      return 0;
+    }
+    const windowStart = now - windowMs;
+    let bytes = 0;
+    const intervals = [];
+    for (let i = 0; i < transfers.length; i += 1) {
+      const tr = transfers[i];
+      if (!tr || !(tr.bytes > 0) || !(tr.end > tr.start)) {
+        continue;
+      }
+      const s = Math.max(tr.start, windowStart);
+      const e = Math.min(tr.end, now);
+      if (e <= s) {
+        continue;
+      }
+      bytes += tr.bytes * ((e - s) / (tr.end - tr.start));
+      intervals.push([s, e]);
+    }
+    return throughputMbps(bytes, unionDurationMs(intervals));
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -413,6 +470,8 @@
     selectTarget,
     alternativesFor,
     throughputMbps,
+    unionDurationMs,
+    aggregateThroughput,
     rankHosts,
     rewriteJsonText,
     rewriteObject,
@@ -808,11 +867,13 @@
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
           meta.url.includes("/pgc/player") || isMedia);
 
-      // Count downloaded bytes for media segments (free via loadend.loaded).
+      // Count downloaded bytes for media segments (free via loadend.loaded) and
+      // time send→loadend as the transfer duration for the throughput window.
       if (config.enabled && isMedia) {
+        const startTs = nowMs();
         xhr.addEventListener("loadend", function onLoadEnd(event) {
           if (event && typeof event.loaded === "number") {
-            addBytes(event.loaded);
+            recordTransfer(startTs, nowMs(), event.loaded);
           }
         });
       }
@@ -1054,7 +1115,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.1",
+      version: "0.2.2",
       installedAt: state.installedAt,
       region: regionKey(),
       config,
@@ -1075,12 +1136,16 @@
 
   const SPEED_SAMPLES = 60;       // ~60s of history at 1s resolution
   const SPEED_TICK_MS = 1000;
+  const SPEED_WINDOW_MS = 3000;   // trailing window for active-throughput math
+  const MIN_TRANSFER_MS = 8;      // ignore sub-8ms reads (cache hits) as rate noise
   const speed = {
     mode: "speed",                // "speed" (Mbps) | "buffer" (seconds ahead)
     mbpsSeries: [],
     bufSeries: [],
-    windowBytes: 0,               // bytes finished within the current tick
-    currentMbps: 0,
+    transfers: [],                // recent { start, end, bytes } media transfers
+    currentMbps: 0,               // displayed (eased) rate — mirrors dispMbps
+    dispMbps: 0,                  // eased value driving the curve + big readout
+    avgMbps: 0,                   // slow average, used as the idle anchor
     peakMbps: 0,
     bufferSec: 0,
     dispMax: 0,                   // eased y-axis maximum (smooth rescaling)
@@ -1090,27 +1155,40 @@
   };
   let speedTimer = null;
 
-  // Bytes are measured at the fetch/XHR layer (see measureFetchBytes and the
-  // XHR loadend counter) rather than via Resource Timing, because Bilibili's
-  // media CDN omits Timing-Allow-Origin and would report 0 transferSize.
-  function addBytes(n) {
-    if (n > 0) {
-      speed.windowBytes += n;
-      speed.sawBytes = true;
+  function nowMs() {
+    return (root.performance && root.performance.now) ? root.performance.now() : Date.now();
+  }
+
+  // Record one completed media transfer for the active-throughput window. Bytes
+  // are measured at the fetch/XHR layer (see measureFetchBytes and the XHR
+  // loadend counter) rather than via Resource Timing, because Bilibili's media
+  // CDN omits Timing-Allow-Origin and would report 0 transferSize.
+  function recordTransfer(start, end, bytes) {
+    if (!(bytes > 0)) {
+      return;
+    }
+    speed.sawBytes = true;
+    // Near-instant reads are cache hits, not the network — counting them would
+    // spike the rate to absurd values, so only their "bytes seen" flag matters.
+    if (end - start >= MIN_TRANSFER_MS) {
+      speed.transfers.push({ start: start, end: end, bytes: bytes });
     }
   }
 
   // Count a media response's bytes by reading a clone — the player still gets
   // the original response untouched, and cloning tees the stream (no re-download).
+  // The clone drains as fast as the network delivers, so start→arrayBuffer is a
+  // clean transfer-duration proxy that excludes idle time between segments.
   function measureFetchBytes(response) {
+    const start = nowMs();
     try {
       response.clone().arrayBuffer().then(function (buf) {
-        addBytes(buf && buf.byteLength);
+        recordTransfer(start, nowMs(), buf && buf.byteLength);
       }).catch(function () {});
     } catch (_) {
       const cl = response.headers && response.headers.get("content-length");
-      if (cl) {
-        addBytes(parseInt(cl, 10) || 0);
+      if (cl && parseInt(cl, 10) > 0) {
+        speed.sawBytes = true;
       }
     }
   }
@@ -1122,17 +1200,14 @@
   }
 
   function tickSpeed() {
-    // True throughput = bytes that finished in the last tick / tick length.
-    const mbps = core.throughputMbps(speed.windowBytes, SPEED_TICK_MS);
-    speed.windowBytes = 0;
-    speed.currentMbps = mbps;
-    if (mbps > speed.peakMbps) {
-      speed.peakMbps = mbps;
-    }
-    speed.mbpsSeries.push(mbps);
-    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
-      speed.mbpsSeries.shift();
-    }
+    const now = nowMs();
+    // Active throughput: bytes per second of time actually spent transferring in
+    // the trailing window, so the player's idle gaps between burst downloads
+    // don't drag a fast link to zero.
+    const sample = core.aggregateThroughput(speed.transfers, now, SPEED_WINDOW_MS);
+    speed.transfers = speed.transfers.filter(function keep(tr) {
+      return tr.end > now - SPEED_WINDOW_MS;
+    });
 
     let playing = false;
     try {
@@ -1146,6 +1221,36 @@
         speed.lastTime = watchedVideo.currentTime;
       }
     } catch (_) {}
+
+    if (sample > 0) {
+      // Downloading: ease up toward the measured rate and keep a slow average
+      // as the anchor to hold at once the burst ends.
+      speed.avgMbps = speed.avgMbps > 0
+        ? speed.avgMbps + (sample - speed.avgMbps) * 0.25
+        : sample;
+      speed.dispMbps += (sample - speed.dispMbps) * 0.45;
+      if (sample > speed.peakMbps) {
+        speed.peakMbps = sample;
+      }
+    } else if (playing) {
+      // Buffer full, nothing in flight: the link is idle, not slow — drift
+      // gently toward the recent average instead of dropping to 0.
+      speed.dispMbps += (speed.avgMbps - speed.dispMbps) * 0.05;
+    } else {
+      // Genuinely idle (paused/ended): relax the reading toward 0.
+      speed.dispMbps *= 0.8;
+      speed.avgMbps *= 0.8;
+    }
+    if (speed.dispMbps < 0.05) {
+      speed.dispMbps = 0;
+    }
+    speed.currentMbps = speed.dispMbps;
+
+    speed.mbpsSeries.push(speed.dispMbps);
+    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
+      speed.mbpsSeries.shift();
+    }
+
     speed.bufSeries.push(speed.bufferSec);
     if (speed.bufSeries.length > SPEED_SAMPLES) {
       speed.bufSeries.shift();
@@ -1277,12 +1382,14 @@
 
     const padTop = 5;
     const padBottom = 2;
-    const step = w / (SPEED_SAMPLES - 1);
-    const offset = SPEED_SAMPLES - series.length;
+    // Elastic x-axis: while the series is still filling, stretch it across the
+    // full width so the curve looks alive from the first seconds; once it caps
+    // at SPEED_SAMPLES the step stabilizes and the window simply slides.
+    const step = w / Math.max(1, series.length - 1);
     const xs = [];
     const ys = [];
     for (let i = 0; i < series.length; i += 1) {
-      xs.push((offset + i) * step);
+      xs.push(i * step);
       ys.push(h - padBottom - (series[i] / max) * (h - padTop - padBottom));
     }
     const tan = series.length >= 2 ? monotoneTangents(xs, ys) : [0];

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -309,6 +309,63 @@
     return (bytes * 8 / 1e6) / (durationMs / 1000);
   }
 
+  // Total length of a set of [start, end] intervals with overlaps merged, so
+  // two segments downloaded in parallel count their shared time only once.
+  function unionDurationMs(intervals) {
+    if (!intervals || !intervals.length) {
+      return 0;
+    }
+    const sorted = intervals.slice().sort(function byStart(a, b) {
+      return a[0] - b[0];
+    });
+    let total = 0;
+    let curStart = sorted[0][0];
+    let curEnd = sorted[0][1];
+    for (let i = 1; i < sorted.length; i += 1) {
+      const s = sorted[i][0];
+      const e = sorted[i][1];
+      if (s > curEnd) {
+        total += curEnd - curStart;
+        curStart = s;
+        curEnd = e;
+      } else if (e > curEnd) {
+        curEnd = e;
+      }
+    }
+    total += curEnd - curStart;
+    return total;
+  }
+
+  // Aggregate "active" throughput: bytes moved per second of time actually spent
+  // transferring, measured over the trailing `windowMs`. Unlike dividing by
+  // wall-clock, idle gaps between the player's burst downloads don't drag the
+  // rate to zero — this reflects the link's real capacity. Bytes from transfers
+  // straddling the window edge are prorated to the in-window fraction, and the
+  // active time is the union of all transfer intervals (parallel video+audio
+  // segments count their overlap once). transfers: [{ start, end, bytes }] in ms.
+  function aggregateThroughput(transfers, now, windowMs) {
+    if (!transfers || !transfers.length || !(windowMs > 0)) {
+      return 0;
+    }
+    const windowStart = now - windowMs;
+    let bytes = 0;
+    const intervals = [];
+    for (let i = 0; i < transfers.length; i += 1) {
+      const tr = transfers[i];
+      if (!tr || !(tr.bytes > 0) || !(tr.end > tr.start)) {
+        continue;
+      }
+      const s = Math.max(tr.start, windowStart);
+      const e = Math.min(tr.end, now);
+      if (e <= s) {
+        continue;
+      }
+      bytes += tr.bytes * ((e - s) / (tr.end - tr.start));
+      intervals.push([s, e]);
+    }
+    return throughputMbps(bytes, unionDurationMs(intervals));
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -396,6 +453,8 @@
     selectTarget,
     alternativesFor,
     throughputMbps,
+    unionDurationMs,
+    aggregateThroughput,
     rankHosts,
     rewriteJsonText,
     rewriteObject,
@@ -791,11 +850,13 @@
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
           meta.url.includes("/pgc/player") || isMedia);
 
-      // Count downloaded bytes for media segments (free via loadend.loaded).
+      // Count downloaded bytes for media segments (free via loadend.loaded) and
+      // time send→loadend as the transfer duration for the throughput window.
       if (config.enabled && isMedia) {
+        const startTs = nowMs();
         xhr.addEventListener("loadend", function onLoadEnd(event) {
           if (event && typeof event.loaded === "number") {
-            addBytes(event.loaded);
+            recordTransfer(startTs, nowMs(), event.loaded);
           }
         });
       }
@@ -1037,7 +1098,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.1",
+      version: "0.2.2",
       installedAt: state.installedAt,
       region: regionKey(),
       config,
@@ -1058,12 +1119,16 @@
 
   const SPEED_SAMPLES = 60;       // ~60s of history at 1s resolution
   const SPEED_TICK_MS = 1000;
+  const SPEED_WINDOW_MS = 3000;   // trailing window for active-throughput math
+  const MIN_TRANSFER_MS = 8;      // ignore sub-8ms reads (cache hits) as rate noise
   const speed = {
     mode: "speed",                // "speed" (Mbps) | "buffer" (seconds ahead)
     mbpsSeries: [],
     bufSeries: [],
-    windowBytes: 0,               // bytes finished within the current tick
-    currentMbps: 0,
+    transfers: [],                // recent { start, end, bytes } media transfers
+    currentMbps: 0,               // displayed (eased) rate — mirrors dispMbps
+    dispMbps: 0,                  // eased value driving the curve + big readout
+    avgMbps: 0,                   // slow average, used as the idle anchor
     peakMbps: 0,
     bufferSec: 0,
     dispMax: 0,                   // eased y-axis maximum (smooth rescaling)
@@ -1073,27 +1138,40 @@
   };
   let speedTimer = null;
 
-  // Bytes are measured at the fetch/XHR layer (see measureFetchBytes and the
-  // XHR loadend counter) rather than via Resource Timing, because Bilibili's
-  // media CDN omits Timing-Allow-Origin and would report 0 transferSize.
-  function addBytes(n) {
-    if (n > 0) {
-      speed.windowBytes += n;
-      speed.sawBytes = true;
+  function nowMs() {
+    return (root.performance && root.performance.now) ? root.performance.now() : Date.now();
+  }
+
+  // Record one completed media transfer for the active-throughput window. Bytes
+  // are measured at the fetch/XHR layer (see measureFetchBytes and the XHR
+  // loadend counter) rather than via Resource Timing, because Bilibili's media
+  // CDN omits Timing-Allow-Origin and would report 0 transferSize.
+  function recordTransfer(start, end, bytes) {
+    if (!(bytes > 0)) {
+      return;
+    }
+    speed.sawBytes = true;
+    // Near-instant reads are cache hits, not the network — counting them would
+    // spike the rate to absurd values, so only their "bytes seen" flag matters.
+    if (end - start >= MIN_TRANSFER_MS) {
+      speed.transfers.push({ start: start, end: end, bytes: bytes });
     }
   }
 
   // Count a media response's bytes by reading a clone — the player still gets
   // the original response untouched, and cloning tees the stream (no re-download).
+  // The clone drains as fast as the network delivers, so start→arrayBuffer is a
+  // clean transfer-duration proxy that excludes idle time between segments.
   function measureFetchBytes(response) {
+    const start = nowMs();
     try {
       response.clone().arrayBuffer().then(function (buf) {
-        addBytes(buf && buf.byteLength);
+        recordTransfer(start, nowMs(), buf && buf.byteLength);
       }).catch(function () {});
     } catch (_) {
       const cl = response.headers && response.headers.get("content-length");
-      if (cl) {
-        addBytes(parseInt(cl, 10) || 0);
+      if (cl && parseInt(cl, 10) > 0) {
+        speed.sawBytes = true;
       }
     }
   }
@@ -1105,17 +1183,14 @@
   }
 
   function tickSpeed() {
-    // True throughput = bytes that finished in the last tick / tick length.
-    const mbps = core.throughputMbps(speed.windowBytes, SPEED_TICK_MS);
-    speed.windowBytes = 0;
-    speed.currentMbps = mbps;
-    if (mbps > speed.peakMbps) {
-      speed.peakMbps = mbps;
-    }
-    speed.mbpsSeries.push(mbps);
-    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
-      speed.mbpsSeries.shift();
-    }
+    const now = nowMs();
+    // Active throughput: bytes per second of time actually spent transferring in
+    // the trailing window, so the player's idle gaps between burst downloads
+    // don't drag a fast link to zero.
+    const sample = core.aggregateThroughput(speed.transfers, now, SPEED_WINDOW_MS);
+    speed.transfers = speed.transfers.filter(function keep(tr) {
+      return tr.end > now - SPEED_WINDOW_MS;
+    });
 
     let playing = false;
     try {
@@ -1129,6 +1204,36 @@
         speed.lastTime = watchedVideo.currentTime;
       }
     } catch (_) {}
+
+    if (sample > 0) {
+      // Downloading: ease up toward the measured rate and keep a slow average
+      // as the anchor to hold at once the burst ends.
+      speed.avgMbps = speed.avgMbps > 0
+        ? speed.avgMbps + (sample - speed.avgMbps) * 0.25
+        : sample;
+      speed.dispMbps += (sample - speed.dispMbps) * 0.45;
+      if (sample > speed.peakMbps) {
+        speed.peakMbps = sample;
+      }
+    } else if (playing) {
+      // Buffer full, nothing in flight: the link is idle, not slow — drift
+      // gently toward the recent average instead of dropping to 0.
+      speed.dispMbps += (speed.avgMbps - speed.dispMbps) * 0.05;
+    } else {
+      // Genuinely idle (paused/ended): relax the reading toward 0.
+      speed.dispMbps *= 0.8;
+      speed.avgMbps *= 0.8;
+    }
+    if (speed.dispMbps < 0.05) {
+      speed.dispMbps = 0;
+    }
+    speed.currentMbps = speed.dispMbps;
+
+    speed.mbpsSeries.push(speed.dispMbps);
+    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
+      speed.mbpsSeries.shift();
+    }
+
     speed.bufSeries.push(speed.bufferSec);
     if (speed.bufSeries.length > SPEED_SAMPLES) {
       speed.bufSeries.shift();
@@ -1260,12 +1365,14 @@
 
     const padTop = 5;
     const padBottom = 2;
-    const step = w / (SPEED_SAMPLES - 1);
-    const offset = SPEED_SAMPLES - series.length;
+    // Elastic x-axis: while the series is still filling, stretch it across the
+    // full width so the curve looks alive from the first seconds; once it caps
+    // at SPEED_SAMPLES the step stabilizes and the window simply slides.
+    const step = w / Math.max(1, series.length - 1);
     const xs = [];
     const ys = [];
     for (let i = 0; i < series.length; i += 1) {
-      xs.push((offset + i) * step);
+      xs.push(i * step);
       ys.push(h - padBottom - (series[i] / max) * (h - padTop - padBottom));
     }
     const tan = series.length >= 2 ? monotoneTangents(xs, ys) : [0];

--- a/dist/extension/manifest.json
+++ b/dist/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
   "icons": {},
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-accelerator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Safari-friendly Bilibili playback CDN accelerator.",
   "scripts": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -16,7 +16,7 @@ const userscriptHeader = `// ==UserScript==
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.2.1
+// @version      0.2.2
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza

--- a/src/core/rewrite.js
+++ b/src/core/rewrite.js
@@ -309,6 +309,63 @@
     return (bytes * 8 / 1e6) / (durationMs / 1000);
   }
 
+  // Total length of a set of [start, end] intervals with overlaps merged, so
+  // two segments downloaded in parallel count their shared time only once.
+  function unionDurationMs(intervals) {
+    if (!intervals || !intervals.length) {
+      return 0;
+    }
+    const sorted = intervals.slice().sort(function byStart(a, b) {
+      return a[0] - b[0];
+    });
+    let total = 0;
+    let curStart = sorted[0][0];
+    let curEnd = sorted[0][1];
+    for (let i = 1; i < sorted.length; i += 1) {
+      const s = sorted[i][0];
+      const e = sorted[i][1];
+      if (s > curEnd) {
+        total += curEnd - curStart;
+        curStart = s;
+        curEnd = e;
+      } else if (e > curEnd) {
+        curEnd = e;
+      }
+    }
+    total += curEnd - curStart;
+    return total;
+  }
+
+  // Aggregate "active" throughput: bytes moved per second of time actually spent
+  // transferring, measured over the trailing `windowMs`. Unlike dividing by
+  // wall-clock, idle gaps between the player's burst downloads don't drag the
+  // rate to zero — this reflects the link's real capacity. Bytes from transfers
+  // straddling the window edge are prorated to the in-window fraction, and the
+  // active time is the union of all transfer intervals (parallel video+audio
+  // segments count their overlap once). transfers: [{ start, end, bytes }] in ms.
+  function aggregateThroughput(transfers, now, windowMs) {
+    if (!transfers || !transfers.length || !(windowMs > 0)) {
+      return 0;
+    }
+    const windowStart = now - windowMs;
+    let bytes = 0;
+    const intervals = [];
+    for (let i = 0; i < transfers.length; i += 1) {
+      const tr = transfers[i];
+      if (!tr || !(tr.bytes > 0) || !(tr.end > tr.start)) {
+        continue;
+      }
+      const s = Math.max(tr.start, windowStart);
+      const e = Math.min(tr.end, now);
+      if (e <= s) {
+        continue;
+      }
+      bytes += tr.bytes * ((e - s) / (tr.end - tr.start));
+      intervals.push([s, e]);
+    }
+    return throughputMbps(bytes, unionDurationMs(intervals));
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -396,6 +453,8 @@
     selectTarget,
     alternativesFor,
     throughputMbps,
+    unionDurationMs,
+    aggregateThroughput,
     rankHosts,
     rewriteJsonText,
     rewriteObject,

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
   "icons": {},
   "permissions": [

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -385,11 +385,13 @@
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
           meta.url.includes("/pgc/player") || isMedia);
 
-      // Count downloaded bytes for media segments (free via loadend.loaded).
+      // Count downloaded bytes for media segments (free via loadend.loaded) and
+      // time send→loadend as the transfer duration for the throughput window.
       if (config.enabled && isMedia) {
+        const startTs = nowMs();
         xhr.addEventListener("loadend", function onLoadEnd(event) {
           if (event && typeof event.loaded === "number") {
-            addBytes(event.loaded);
+            recordTransfer(startTs, nowMs(), event.loaded);
           }
         });
       }
@@ -631,7 +633,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.1",
+      version: "0.2.2",
       installedAt: state.installedAt,
       region: regionKey(),
       config,
@@ -652,12 +654,16 @@
 
   const SPEED_SAMPLES = 60;       // ~60s of history at 1s resolution
   const SPEED_TICK_MS = 1000;
+  const SPEED_WINDOW_MS = 3000;   // trailing window for active-throughput math
+  const MIN_TRANSFER_MS = 8;      // ignore sub-8ms reads (cache hits) as rate noise
   const speed = {
     mode: "speed",                // "speed" (Mbps) | "buffer" (seconds ahead)
     mbpsSeries: [],
     bufSeries: [],
-    windowBytes: 0,               // bytes finished within the current tick
-    currentMbps: 0,
+    transfers: [],                // recent { start, end, bytes } media transfers
+    currentMbps: 0,               // displayed (eased) rate — mirrors dispMbps
+    dispMbps: 0,                  // eased value driving the curve + big readout
+    avgMbps: 0,                   // slow average, used as the idle anchor
     peakMbps: 0,
     bufferSec: 0,
     dispMax: 0,                   // eased y-axis maximum (smooth rescaling)
@@ -667,27 +673,40 @@
   };
   let speedTimer = null;
 
-  // Bytes are measured at the fetch/XHR layer (see measureFetchBytes and the
-  // XHR loadend counter) rather than via Resource Timing, because Bilibili's
-  // media CDN omits Timing-Allow-Origin and would report 0 transferSize.
-  function addBytes(n) {
-    if (n > 0) {
-      speed.windowBytes += n;
-      speed.sawBytes = true;
+  function nowMs() {
+    return (root.performance && root.performance.now) ? root.performance.now() : Date.now();
+  }
+
+  // Record one completed media transfer for the active-throughput window. Bytes
+  // are measured at the fetch/XHR layer (see measureFetchBytes and the XHR
+  // loadend counter) rather than via Resource Timing, because Bilibili's media
+  // CDN omits Timing-Allow-Origin and would report 0 transferSize.
+  function recordTransfer(start, end, bytes) {
+    if (!(bytes > 0)) {
+      return;
+    }
+    speed.sawBytes = true;
+    // Near-instant reads are cache hits, not the network — counting them would
+    // spike the rate to absurd values, so only their "bytes seen" flag matters.
+    if (end - start >= MIN_TRANSFER_MS) {
+      speed.transfers.push({ start: start, end: end, bytes: bytes });
     }
   }
 
   // Count a media response's bytes by reading a clone — the player still gets
   // the original response untouched, and cloning tees the stream (no re-download).
+  // The clone drains as fast as the network delivers, so start→arrayBuffer is a
+  // clean transfer-duration proxy that excludes idle time between segments.
   function measureFetchBytes(response) {
+    const start = nowMs();
     try {
       response.clone().arrayBuffer().then(function (buf) {
-        addBytes(buf && buf.byteLength);
+        recordTransfer(start, nowMs(), buf && buf.byteLength);
       }).catch(function () {});
     } catch (_) {
       const cl = response.headers && response.headers.get("content-length");
-      if (cl) {
-        addBytes(parseInt(cl, 10) || 0);
+      if (cl && parseInt(cl, 10) > 0) {
+        speed.sawBytes = true;
       }
     }
   }
@@ -699,17 +718,14 @@
   }
 
   function tickSpeed() {
-    // True throughput = bytes that finished in the last tick / tick length.
-    const mbps = core.throughputMbps(speed.windowBytes, SPEED_TICK_MS);
-    speed.windowBytes = 0;
-    speed.currentMbps = mbps;
-    if (mbps > speed.peakMbps) {
-      speed.peakMbps = mbps;
-    }
-    speed.mbpsSeries.push(mbps);
-    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
-      speed.mbpsSeries.shift();
-    }
+    const now = nowMs();
+    // Active throughput: bytes per second of time actually spent transferring in
+    // the trailing window, so the player's idle gaps between burst downloads
+    // don't drag a fast link to zero.
+    const sample = core.aggregateThroughput(speed.transfers, now, SPEED_WINDOW_MS);
+    speed.transfers = speed.transfers.filter(function keep(tr) {
+      return tr.end > now - SPEED_WINDOW_MS;
+    });
 
     let playing = false;
     try {
@@ -723,6 +739,36 @@
         speed.lastTime = watchedVideo.currentTime;
       }
     } catch (_) {}
+
+    if (sample > 0) {
+      // Downloading: ease up toward the measured rate and keep a slow average
+      // as the anchor to hold at once the burst ends.
+      speed.avgMbps = speed.avgMbps > 0
+        ? speed.avgMbps + (sample - speed.avgMbps) * 0.25
+        : sample;
+      speed.dispMbps += (sample - speed.dispMbps) * 0.45;
+      if (sample > speed.peakMbps) {
+        speed.peakMbps = sample;
+      }
+    } else if (playing) {
+      // Buffer full, nothing in flight: the link is idle, not slow — drift
+      // gently toward the recent average instead of dropping to 0.
+      speed.dispMbps += (speed.avgMbps - speed.dispMbps) * 0.05;
+    } else {
+      // Genuinely idle (paused/ended): relax the reading toward 0.
+      speed.dispMbps *= 0.8;
+      speed.avgMbps *= 0.8;
+    }
+    if (speed.dispMbps < 0.05) {
+      speed.dispMbps = 0;
+    }
+    speed.currentMbps = speed.dispMbps;
+
+    speed.mbpsSeries.push(speed.dispMbps);
+    if (speed.mbpsSeries.length > SPEED_SAMPLES) {
+      speed.mbpsSeries.shift();
+    }
+
     speed.bufSeries.push(speed.bufferSec);
     if (speed.bufSeries.length > SPEED_SAMPLES) {
       speed.bufSeries.shift();
@@ -854,12 +900,14 @@
 
     const padTop = 5;
     const padBottom = 2;
-    const step = w / (SPEED_SAMPLES - 1);
-    const offset = SPEED_SAMPLES - series.length;
+    // Elastic x-axis: while the series is still filling, stretch it across the
+    // full width so the curve looks alive from the first seconds; once it caps
+    // at SPEED_SAMPLES the step stabilizes and the window simply slides.
+    const step = w / Math.max(1, series.length - 1);
     const xs = [];
     const ys = [];
     for (let i = 0; i < series.length; i += 1) {
-      xs.push((offset + i) * step);
+      xs.push(i * step);
       ys.push(h - padBottom - (series[i] / max) * (h - padTop - padBottom));
     }
     const tan = series.length >= 2 ? monotoneTangents(xs, ys) : [0];

--- a/test/v2-core.test.js
+++ b/test/v2-core.test.js
@@ -107,6 +107,42 @@ test("throughputMbps converts bytes over a window to megabits per second", () =>
   assert.equal(core.throughputMbps(1000, 0), 0);
 });
 
+test("unionDurationMs merges overlapping intervals", () => {
+  // two back-to-back non-overlapping intervals: 100 + 100 = 200
+  assert.equal(core.unionDurationMs([[0, 100], [200, 300]]), 200);
+  // fully overlapping parallel transfers count their shared time once
+  assert.equal(core.unionDurationMs([[0, 100], [0, 100]]), 100);
+  // partial overlap merges into a single span
+  assert.equal(core.unionDurationMs([[0, 100], [50, 150]]), 150);
+  assert.equal(core.unionDurationMs([]), 0);
+});
+
+test("aggregateThroughput measures active rate, not wall-clock", () => {
+  // 1,000,000 bytes downloaded in a 100ms burst, then idle. Over a 3s window
+  // this is the burst's real rate (80 Mbps), NOT smeared to ~2.7 Mbps.
+  const burst = [{ start: 0, end: 100, bytes: 1e6 }];
+  assert.equal(core.aggregateThroughput(burst, 3000, 3000), 80);
+
+  // Parallel video+audio segments over the same 100ms move a combined
+  // 1,000,000 bytes: union active time is 100ms, so the link reads 80 Mbps.
+  const parallel = [
+    { start: 0, end: 100, bytes: 6e5 },
+    { start: 0, end: 100, bytes: 4e5 }
+  ];
+  assert.equal(core.aggregateThroughput(parallel, 3000, 3000), 80);
+
+  // No transfers in the window ⇒ 0 (the idle-hold lives in the page layer).
+  assert.equal(core.aggregateThroughput([{ start: 0, end: 100, bytes: 1e6 }], 5000, 3000), 0);
+});
+
+test("aggregateThroughput prorates a transfer straddling the window edge", () => {
+  // A 200ms transfer of 2,000,000 bytes (2900→3100ms) with a 100ms window
+  // (3000→3100): only the last half is inside, so half the bytes over 100ms of
+  // active time = 80 Mbps.
+  const straddling = [{ start: 2900, end: 3100, bytes: 2e6 }];
+  assert.equal(core.aggregateThroughput(straddling, 3100, 100), 80);
+});
+
 test("rankHosts orders healthy hosts by TTFB and sinks failures", () => {
   const ranked = core.rankHosts([
     { host: "slow.bilivideo.com", ttfb: 800, ok: true },

--- a/test/v2-page.test.js
+++ b/test/v2-page.test.js
@@ -75,6 +75,6 @@ test("public API exposes diagnostics and config control", () => {
   const cfg = sandbox.BiliAccelerator.setConfig({ p2pGuard: true });
   assert.equal(cfg.p2pGuard, true);
   const diag = sandbox.BiliAccelerator.getDiagnostics();
-  assert.equal(diag.version, "0.2.1");
+  assert.equal(diag.version, "0.2.2");
   assert.ok(diag.counters && typeof diag.counters.rewrites === "number");
 });


### PR DESCRIPTION
## Why

The live download-speed curve **dropped to 0 on most ticks** and understated its peaks, so a genuinely fast connection looked slow. This was a measurement artifact, not the network.

Two root causes → two fixes.

### 1. Bursty measurement → active-throughput window

DASH players burst-download to fill the buffer, then go **idle** until it drains. The old meter divided bytes by **wall-clock** time each second, so:
- idle seconds read as **0 Mbps** (no demand ≠ slow link), and
- a sub-second burst spread over a 1s bucket read **far below** the real rate.

In a simulated 100 Mbps link streaming ~8 Mbps video (one ~0.3s burst every 4s), the old meter showed `0` on 3 of every 4 ticks and only `32` on the rest. The new meter converges to the true ~100 and holds steady.

Now each media transfer records `{start, end, bytes}`, and a new pure `core.aggregateThroughput()` computes bytes over the **union of active transfer time** within a 3s window — the link's real capacity, unaffected by idle gaps (parallel video+audio overlap counts once; edge-straddling transfers are prorated). The displayed value:
- eases toward the measured rate while downloading,
- **holds** near the recent average when the buffer is full during playback (idle ≠ slow),
- relaxes to 0 only when actually paused/ended.

### 2. Fixed-grid x-axis → elastic then sliding

The chart always plotted against a fixed 60-wide grid, so early on the curve hugged the right corner. It's now **elastic**: points stretch across the full width while the series fills, then lock into a sliding 60s window once capped (`step = w / max(1, n-1)`).

## Tests
- New unit tests for `unionDurationMs` and `aggregateThroughput` (parallel, idle, edge-straddle cases).
- Full suite green (30 tests); `npm run build` regenerated `dist/`.
- Version bumped to **0.2.2**.

## Note
Logic is verified by unit tests + a numeric stream simulation. Real-player visual verification on Bilibili still recommended before shipping, since transfer timing (fetch clone drain / XHR `send→loadend`) is measured against live traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)