### PR TITLE
Redact media URLs from the diagnostics report

### DIFF
--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -17,7 +17,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1)
+- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
@@ -74,7 +74,7 @@ In web fullscreen the ⚡ icon fades out so it never covers the video; move the 
 - **Plain-language panel** — one status (Playing smoothly / Finding a faster server), one switch, one "Boost harder" button. Every old knob still lives under **Advanced settings**.
 - **Optional bandwidth guard** — stop Bilibili from using your upload via WebRTC P2P (off by default).
 - **Toolbar popup + synced settings** for the browser extension.
-- **Live speed graph** *(0.2.1)* — a real-time download-speed chart right in the panel, with a buffer-health fallback when a CDN hides byte sizes.
+- **Live speed graph** *(0.2.1, refined in 0.2.2)* — a real-time download-speed chart right in the panel. It measures throughput over the time data is actually flowing, so a fast link reads high and steady instead of flickering to zero between buffer fills. Falls back to buffer health when a CDN hides byte sizes.
 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="Advanced settings: auto server selection, hidden-PCDN detection, live auto-recover, bandwidth guard" width="360">

--- a/dist/README.md
+++ b/dist/README.md
@@ -17,7 +17,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1)
+- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
@@ -74,7 +74,7 @@ proxy-tf-all-ws.bilivideo.com
 - **大白话面板**：一个状态（流畅播放 / 正在找更快的服务器）、一个开关、一个「再加把劲」按钮。所有老选项都收进 **Advanced settings（高级设置）**。
 - **可选的带宽保护**：阻止 B 站通过 WebRTC P2P 占用你的上传带宽（默认关闭）。
 - **浏览器扩展新增工具栏弹窗与设置同步。**
-- **实时速度图** *(0.2.1)*：面板内置实时下载速度曲线，当 CDN 不暴露字节数时自动回退为缓冲时长。
+- **实时速度图** *(0.2.1，0.2.2 优化)*：面板内置实时下载速度曲线。速度按真正在传输数据的时段来计算，因此快网络会稳定显示高速，而不会在缓冲填满的间隙频繁掉到 0；当 CDN 不暴露字节数时自动回退为缓冲时长。
 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="高级设置：自动选最快服务器、隐藏 PCDN 识别、卡顿自动恢复、带宽保护" width="360">

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -383,6 +383,17 @@
     return throughputMbps(bytes, unionDurationMs(intervals));
   }
 
+  // Bare host[:port] of a URL, for diagnostics that must never carry the query
+  // string — segment URLs pack the viewer's mid, buvid, IP-derived oi and signed
+  // access tokens there, and the report is meant to be shared. "" on failure.
+  function hostOf(value) {
+    try {
+      return new URL(String(value)).host;
+    } catch (_) {
+      return "";
+    }
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -472,6 +483,7 @@
     throughputMbps,
     unionDurationMs,
     aggregateThroughput,
+    hostOf,
     rankHosts,
     rewriteJsonText,
     rewriteObject,
@@ -606,13 +618,16 @@
     state.lastSource = source;
     state.rewriteCount += rewrites.length;
     state.rewrites = state.rewrites.concat(rewrites.map(function mapRewrite(item) {
+      // Keep only bare host + reason — never the full media URL. Segment URLs
+      // carry the viewer's mid, buvid, IP-derived oi and signed tokens, and the
+      // diagnostics report is built to be pasted into public issues. Redacting
+      // here (not just at display) means those tokens never persist in memory.
       return {
         at: new Date().toISOString(),
         source,
         reason: item.reason,
-        targetHost: item.targetHost,
-        from: item.original,
-        to: item.url
+        fromHost: core.hostOf(item.original),
+        toHost: core.hostOf(item.url)
       };
     })).slice(-50);
     if (state.status === "idle") {
@@ -1117,7 +1132,7 @@
     return {
       version: "0.2.2",
       installedAt: state.installedAt,
-      region: regionKey(),
+      region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
       status: state.status,
       counters: {

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -366,6 +366,17 @@
     return throughputMbps(bytes, unionDurationMs(intervals));
   }
 
+  // Bare host[:port] of a URL, for diagnostics that must never carry the query
+  // string — segment URLs pack the viewer's mid, buvid, IP-derived oi and signed
+  // access tokens there, and the report is meant to be shared. "" on failure.
+  function hostOf(value) {
+    try {
+      return new URL(String(value)).host;
+    } catch (_) {
+      return "";
+    }
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -455,6 +466,7 @@
     throughputMbps,
     unionDurationMs,
     aggregateThroughput,
+    hostOf,
     rankHosts,
     rewriteJsonText,
     rewriteObject,
@@ -589,13 +601,16 @@
     state.lastSource = source;
     state.rewriteCount += rewrites.length;
     state.rewrites = state.rewrites.concat(rewrites.map(function mapRewrite(item) {
+      // Keep only bare host + reason — never the full media URL. Segment URLs
+      // carry the viewer's mid, buvid, IP-derived oi and signed tokens, and the
+      // diagnostics report is built to be pasted into public issues. Redacting
+      // here (not just at display) means those tokens never persist in memory.
       return {
         at: new Date().toISOString(),
         source,
         reason: item.reason,
-        targetHost: item.targetHost,
-        from: item.original,
-        to: item.url
+        fromHost: core.hostOf(item.original),
+        toHost: core.hostOf(item.url)
       };
     })).slice(-50);
     if (state.status === "idle") {
@@ -1100,7 +1115,7 @@
     return {
       version: "0.2.2",
       installedAt: state.installedAt,
-      region: regionKey(),
+      region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
       status: state.status,
       counters: {

--- a/src/core/rewrite.js
+++ b/src/core/rewrite.js
@@ -366,6 +366,17 @@
     return throughputMbps(bytes, unionDurationMs(intervals));
   }
 
+  // Bare host[:port] of a URL, for diagnostics that must never carry the query
+  // string — segment URLs pack the viewer's mid, buvid, IP-derived oi and signed
+  // access tokens there, and the report is meant to be shared. "" on failure.
+  function hostOf(value) {
+    try {
+      return new URL(String(value)).host;
+    } catch (_) {
+      return "";
+    }
+  }
+
   // Pure ranking of probed hosts. samples: [{host, ttfb:number|null, ok:bool}].
   // Healthy hosts first (lowest TTFB wins); failures sink to the bottom.
   function rankHosts(samples) {
@@ -455,6 +466,7 @@
     throughputMbps,
     unionDurationMs,
     aggregateThroughput,
+    hostOf,
     rankHosts,
     rewriteJsonText,
     rewriteObject,

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -124,13 +124,16 @@
     state.lastSource = source;
     state.rewriteCount += rewrites.length;
     state.rewrites = state.rewrites.concat(rewrites.map(function mapRewrite(item) {
+      // Keep only bare host + reason — never the full media URL. Segment URLs
+      // carry the viewer's mid, buvid, IP-derived oi and signed tokens, and the
+      // diagnostics report is built to be pasted into public issues. Redacting
+      // here (not just at display) means those tokens never persist in memory.
       return {
         at: new Date().toISOString(),
         source,
         reason: item.reason,
-        targetHost: item.targetHost,
-        from: item.original,
-        to: item.url
+        fromHost: core.hostOf(item.original),
+        toHost: core.hostOf(item.url)
       };
     })).slice(-50);
     if (state.status === "idle") {
@@ -635,7 +638,7 @@
     return {
       version: "0.2.2",
       installedAt: state.installedAt,
-      region: regionKey(),
+      region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
       status: state.status,
       counters: {

--- a/test/v2-core.test.js
+++ b/test/v2-core.test.js
@@ -143,6 +143,19 @@ test("aggregateThroughput prorates a transfer straddling the window edge", () =>
   assert.equal(core.aggregateThroughput(straddling, 3100, 100), 80);
 });
 
+test("hostOf returns bare host[:port] and drops the query string", () => {
+  assert.equal(
+    core.hostOf("https://upos-sz-mirrorcos.bilivideo.com/x.m4s?mid=1&buvid=SECRET&upsig=tok"),
+    "upos-sz-mirrorcos.bilivideo.com"
+  );
+  // keeps a non-default port (useful PCDN signal), still no query
+  assert.equal(
+    core.hostOf("https://node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?os=mcdn&oi=123"),
+    "node-7.edge.mountaintoys.cn:4830"
+  );
+  assert.equal(core.hostOf("not a url"), "");
+});
+
 test("rankHosts orders healthy hosts by TTFB and sinks failures", () => {
   const ranked = core.rankHosts([
     { host: "slow.bilivideo.com", ttfb: 800, ok: true },

--- a/test/v2-page.test.js
+++ b/test/v2-page.test.js
@@ -70,6 +70,32 @@ test("advanced toggle is pinned as the panel footer (stays under cursor)", () =>
   assert.ok(toggleIdx > bodyIdx, "advToggle is the bottom-most element");
 });
 
+test("diagnostics redacts media URLs to bare hosts (no tokens leak)", () => {
+  const sandbox = loadPage();
+  // A PCDN payload whose URL carries account/device/token params. Parsing it
+  // triggers the rewrite + record() path.
+  sandbox.JSON.parse(JSON.stringify({
+    data: { dash: { video: [{
+      baseUrl: "https://node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?os=mcdn&mid=404508679&buvid=SECRETDEVICE&upsig=TOKEN",
+      backupUrl: []
+    }] } }
+  }));
+  const diag = sandbox.BiliAccelerator.getDiagnostics();
+  assert.ok(diag.recentRewrites.length > 0, "records the rewrite");
+  const entry = diag.recentRewrites[0];
+  assert.ok(entry.fromHost, "keeps a source host");
+  assert.ok(entry.toHost, "keeps a target host");
+  assert.equal(entry.from, undefined, "no raw from URL");
+  assert.equal(entry.to, undefined, "no raw to URL");
+  // The whole shared blob must not carry account/device/token material.
+  const blob = JSON.stringify(diag);
+  ["mid=404508679", "SECRETDEVICE", "buvid", "upsig", "TOKEN", "?"].forEach((needle) => {
+    assert.ok(blob.indexOf(needle) === -1, `report leaks "${needle}"`);
+  });
+  // region is trimmed to a bare timezone (no locale).
+  assert.ok(diag.region.indexOf("|") === -1, "region drops locale");
+});
+
 test("public API exposes diagnostics and config control", () => {
   const sandbox = loadPage();
   const cfg = sandbox.BiliAccelerator.setConfig({ p2pGuard: true });


### PR DESCRIPTION
## Why

The **Copy report** button (`buildDiagnostics()`) is designed to be pasted into public GitHub issues, but `recentRewrites` carried the full media segment URLs. Their query strings leak, per URL:

- `mid` — the viewer's Bilibili account id
- `buvid` — persistent device/browser fingerprint
- `oi` — IP-derived integer
- `upsig` / `hdnts=…hmac=…` — signed access tokens
- the video id in the path — watch history

Present since the diagnostics feature shipped in **v0.2.0** (2026-06-30), through v0.2.1 and v0.2.2. On-page this is nothing bilibili.com doesn't already have — the risk is that our own button packages it and invites the user to publish it.

## Fix

Redact **at the source** in `record()`, not just at display: store only `fromHost` / `toHost` (bare host[:port] via a new pure `core.hostOf`) plus `reason` / `source`. The tokens never enter `state.rewrites`, so they can't leak through the report **or** the `getStats()` / `getDiagnostics()` page APIs. Also trims the reported `region` to a bare timezone (drops locale).

The report keeps all its diagnostic value — an issue now shows `mirrorcosov → mirrorali (cdn-host)`, which is the signal that actually matters. Acceleration behavior is unchanged (nothing reads `.from`/`.to`).

## Scope

Folded into **0.2.2** — no version bump, no new release. Adds a `hostOf` unit test and a regression test asserting the diagnostics blob contains no `mid`/`buvid`/`upsig`/token/query material. Full suite green (32 tests); `dist/` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)