### PR TITLE
v0.2.3: live-stream safety, honest probing, wider PCDN coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Unit tests
+        run: node --test
+      - name: Build
+        run: node scripts/build.mjs
+      - name: dist/ is committed in sync with src/
+        run: git diff --exit-code -- dist

--- a/README.en.md
+++ b/README.en.md
@@ -17,7 +17,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
+- [GitHub Release v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
@@ -79,6 +79,17 @@ In web fullscreen the ⚡ icon fades out so it never covers the video; move the 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="Advanced settings: auto server selection, hidden-PCDN detection, live auto-recover, bandwidth guard" width="360">
 </p>
+
+## What's New in 0.2.3
+
+0.2.3 is a correctness and coverage release:
+
+- **Live streams are now safe** — live (`/live-bvc/`) media URLs are never host-swapped or proxied (VOD mirrors can't serve them), and PCDN/MCDN entries are filtered out of the live room's server list so the live player only dials official CDN hosts.
+- **Smarter server probing** — probes now read the real HTTP status (a fast-failing server can no longer win the ranking) and abort the download right after timing the response, instead of silently pulling full video segments during each probe.
+- **More PCDN families caught** — `upos-*302*` redirect hosts and the residential-node domains they land on, plus PCDN hosts hiding behind mirror-style names.
+- **Fewer escapes** — requests made with `URL` objects, protocol-relative URLs, bangumi (`video_info.dash`) payloads, and legacy `durl` playlists are all covered now.
+- **Stall recovery that keeps trying** — recovery now tracks the server that actually stalled (not the player's internal blob URL) and keeps rotating while buffering persists instead of switching exactly once.
+- **Bandwidth guard hardening** — the opt-in guard also stubs Bilibili's P2P SDK entry points (`PCDNLoader`, `BPP2PSDK`, `SeederSDK`).
 
 ## Tested Case
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
+- [GitHub Release v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
@@ -79,6 +79,17 @@ proxy-tf-all-ws.bilivideo.com
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="高级设置：自动选最快服务器、隐藏 PCDN 识别、卡顿自动恢复、带宽保护" width="360">
 </p>
+
+## 0.2.3 更新
+
+0.2.3 是一次正确性与覆盖率升级：
+
+- **直播不再误伤** —— 直播（`/live-bvc/`）地址不再被换到点播镜像（那些服务器根本放不了直播），并且会从直播间的服务器列表里过滤掉 PCDN/MCDN 节点，让直播播放器只连官方 CDN。
+- **测速更聪明** —— 探测候选服务器时会读取真实 HTTP 状态（秒回错误的服务器不会再赢得排名），并在拿到响应后立刻中断下载，不再在每次探测时偷偷拉整段视频。
+- **识别更多 PCDN 家族** —— 新增 `upos-*302*` 跳转节点及其落地的家用宽带域名，以及伪装成镜像名的 PCDN 服务器。
+- **漏网更少** —— `URL` 对象请求、协议相对地址、番剧（`video_info.dash`）返回、老式 `durl` 播放列表全部覆盖。
+- **卡顿恢复更执着** —— 现在记录真正卡住的服务器（而不是播放器内部的 blob 地址），并且在持续缓冲时不断轮换，而不是只切一次。
+- **带宽保护加固** —— 可选的带宽保护同时屏蔽 B 站 P2P SDK 入口（`PCDNLoader`、`BPP2PSDK`、`SeederSDK`）。
 
 ## 已测样本
 

--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -17,7 +17,7 @@ Greasy Fork is the recommended install path. It works with Chrome, Safari, Firef
 - [Greasy Fork script page](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [Direct `.user.js` install](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw fallback](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
+- [GitHub Release v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3)
 
 After installation, open any Bilibili video. A small ⚡ icon in the lower-right corner means the script is active.
 
@@ -79,6 +79,17 @@ In web fullscreen the ⚡ icon fades out so it never covers the video; move the 
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="Advanced settings: auto server selection, hidden-PCDN detection, live auto-recover, bandwidth guard" width="360">
 </p>
+
+## What's New in 0.2.3
+
+0.2.3 is a correctness and coverage release:
+
+- **Live streams are now safe** — live (`/live-bvc/`) media URLs are never host-swapped or proxied (VOD mirrors can't serve them), and PCDN/MCDN entries are filtered out of the live room's server list so the live player only dials official CDN hosts.
+- **Smarter server probing** — probes now read the real HTTP status (a fast-failing server can no longer win the ranking) and abort the download right after timing the response, instead of silently pulling full video segments during each probe.
+- **More PCDN families caught** — `upos-*302*` redirect hosts and the residential-node domains they land on, plus PCDN hosts hiding behind mirror-style names.
+- **Fewer escapes** — requests made with `URL` objects, protocol-relative URLs, bangumi (`video_info.dash`) payloads, and legacy `durl` playlists are all covered now.
+- **Stall recovery that keeps trying** — recovery now tracks the server that actually stalled (not the player's internal blob URL) and keeps rotating while buffering persists instead of switching exactly once.
+- **Bandwidth guard hardening** — the opt-in guard also stubs Bilibili's P2P SDK entry points (`PCDNLoader`, `BPP2PSDK`, `SeederSDK`).
 
 ## Tested Case
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -17,7 +17,7 @@
 - [Greasy Fork 官方脚本页](https://greasyfork.org/en/scripts/582026-bilibili-accelerator)
 - [直接安装 `.user.js`](https://update.greasyfork.org/scripts/582026/Bilibili%20Accelerator.user.js)
 - [GitHub Raw 备用源](https://raw.githubusercontent.com/realzza/bilibili-accelerator/main/dist/bilibili-accelerator.user.js)
-- [GitHub Release v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2)
+- [GitHub Release v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3)
 
 装好后打开任意 B 站视频。右下角出现 ⚡ 小图标，就说明脚本已经生效。
 
@@ -79,6 +79,17 @@ proxy-tf-all-ws.bilivideo.com
 <p align="center">
   <img src="docs/assets/panel-advanced.png" alt="高级设置：自动选最快服务器、隐藏 PCDN 识别、卡顿自动恢复、带宽保护" width="360">
 </p>
+
+## 0.2.3 更新
+
+0.2.3 是一次正确性与覆盖率升级：
+
+- **直播不再误伤** —— 直播（`/live-bvc/`）地址不再被换到点播镜像（那些服务器根本放不了直播），并且会从直播间的服务器列表里过滤掉 PCDN/MCDN 节点，让直播播放器只连官方 CDN。
+- **测速更聪明** —— 探测候选服务器时会读取真实 HTTP 状态（秒回错误的服务器不会再赢得排名），并在拿到响应后立刻中断下载，不再在每次探测时偷偷拉整段视频。
+- **识别更多 PCDN 家族** —— 新增 `upos-*302*` 跳转节点及其落地的家用宽带域名，以及伪装成镜像名的 PCDN 服务器。
+- **漏网更少** —— `URL` 对象请求、协议相对地址、番剧（`video_info.dash`）返回、老式 `durl` 播放列表全部覆盖。
+- **卡顿恢复更执着** —— 现在记录真正卡住的服务器（而不是播放器内部的 blob 地址），并且在持续缓冲时不断轮换，而不是只切一次。
+- **带宽保护加固** —— 可选的带宽保护同时屏蔽 B 站 P2P SDK 入口（`PCDNLoader`、`BPP2PSDK`、`SeederSDK`）。
 
 ## 已测样本
 

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -2,7 +2,7 @@
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.2.2
+// @version      0.2.3
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza
@@ -74,6 +74,35 @@
   const IP_RE = /^(?:\d{1,3}\.){3}\d{1,3}$/;
   const XY_MCDN_RE = /^xy(?:\d+x){3}\d+xy\.mcdn\.bilivideo\.(?:cn|com|net)$/i;
 
+  // P2P/PCDN families known from community research (Bilibili-Evolved, MBGTEB):
+  // szbdyd is the legacy scheduler, mountaintoys the 2025 rename, nexusedgeio and
+  // ahdohpiechei are where the upos-*302* redirect hosts land, and mirror14b is a
+  // mirror-named host that actually serves PCDN (its TLS cert is *.bilivideo.cn).
+  const KNOWN_P2P_SUFFIXES = Object.freeze([
+    ".szbdyd.com",
+    ".mountaintoys.cn",
+    ".nexusedgeio.com",
+    ".ahdohpiechei.com"
+  ]);
+  const KNOWN_P2P_HOSTS = Object.freeze([
+    "upos-sz-mirror14b.bilivideo.com"
+  ]);
+
+  function isKnownP2pHost(hostname) {
+    if (KNOWN_P2P_HOSTS.indexOf(hostname) !== -1) {
+      return true;
+    }
+    for (let i = 0; i < KNOWN_P2P_SUFFIXES.length; i += 1) {
+      if (hostname.length > KNOWN_P2P_SUFFIXES[i].length &&
+          hostname.indexOf(KNOWN_P2P_SUFFIXES[i]) === hostname.length - KNOWN_P2P_SUFFIXES[i].length) {
+        return true;
+      }
+    }
+    // upos-sz-302ppio / upos-sz-302kodo style hosts answer with an HTTP 302 to a
+    // residential P2P node; the "302" only ever appears in that first label.
+    return hostname.indexOf("upos-") === 0 && hostname.split(".")[0].indexOf("302") !== -1;
+  }
+
   // Forward-migrate any stored config (v1 or partial) onto the v2 defaults.
   function normalizeConfig(config) {
     const merged = Object.assign({}, DEFAULT_CONFIG, config || {});
@@ -98,6 +127,9 @@
       (value.includes("bilivideo") ||
         value.includes("akamaized.net") ||
         value.includes("szbdyd.com") ||
+        value.includes("mountaintoys") ||
+        value.includes("nexusedgeio") ||
+        value.includes("ahdohpiechei") ||
         value.includes("mcdn.bili") ||
         value.includes("os=mcdn") ||
         value.includes("/upgcxcode/") ||
@@ -110,7 +142,8 @@
     }
 
     try {
-      const url = new URL(value);
+      // Payloads occasionally carry protocol-relative URLs ("//host/path").
+      const url = new URL(value.slice(0, 2) === "//" ? "https:" + value : value);
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         return null;
       }
@@ -124,6 +157,14 @@
     return MEDIA_PATH_RE.test(url.pathname + url.search) ||
       url.pathname.startsWith("/upgcxcode/") ||
       url.pathname.startsWith("/v1/resource/");
+  }
+
+  // Live streams (/live-bvc/ FLV & HLS) are served by a separate CDN tier — the
+  // VOD upos mirrors and the MCDN proxy cannot serve them, so a host swap or
+  // proxy wrap would hard-break live playback. Live PCDN is handled upstream by
+  // filtering the getRoomPlayInfo host list instead (see filterLiveUrlInfo).
+  function isLiveMediaUrl(url) {
+    return url.pathname.indexOf("/live-bvc/") !== -1;
   }
 
   function isMcdnHost(hostname) {
@@ -171,15 +212,16 @@
     const akamai = hostname.endsWith(".akamaized.net");
     const portPcdn = config.portHeuristic && hasNonDefaultPort(url);
     const queryMcdn = hasMcdnQuery(url);
+    const knownP2p = isKnownP2pHost(hostname);
 
-    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn;
+    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn || knownP2p;
 
     let kind = "unknown";
     if (schedulerSource !== null || hostname.endsWith(".szbdyd.com")) {
       kind = "scheduler";
     } else if (mcdn) {
       kind = "mcdn";
-    } else if (ipLike || xyMcdn || portPcdn || queryMcdn) {
+    } else if (isPcdn) {
       kind = "pcdn";
     } else if (akamai) {
       kind = "akamai";
@@ -250,6 +292,10 @@
       return { changed: false, original, url: original, reason: "ignored" };
     }
 
+    if (isLiveMediaUrl(url)) {
+      return { changed: false, original, url: original, reason: "live-skip" };
+    }
+
     const verdict = classify(url, config);
 
     if (verdict.schedulerSource) {
@@ -299,7 +345,7 @@
   function alternativesFor(value, rawConfig, hosts) {
     const config = normalizeConfig(rawConfig);
     const url = parseUrl(String(value || ""));
-    if (!url || !isMediaUrl(url)) {
+    if (!url || !isMediaUrl(url) || isLiveMediaUrl(url)) {
       return [];
     }
     const pool = (hosts && hosts.length ? hosts : config.candidatePool) || [];
@@ -457,6 +503,84 @@
     return value;
   }
 
+  // Live playurl payloads (getRoomPlayInfo) don't carry full media URLs — each
+  // stream/format/codec entry lists candidate hosts in url_info: [{host, extra}].
+  // A host like "https://xy…xy.mcdn.bilivideo.cn:486" is a residential PCDN node;
+  // slow for overseas viewers. This decides "is this live host slow" from the
+  // same behavioral signals as classify(), minus the media-path requirement.
+  function isSlowLiveHost(hostValue, extra, rawConfig) {
+    const config = normalizeConfig(rawConfig);
+    const raw = String(hostValue || "");
+    let url;
+    try {
+      url = new URL(raw.indexOf("://") !== -1 ? raw : "https://" + raw.replace(/^\/\//, ""));
+    } catch (_) {
+      return false;
+    }
+    const hostname = url.hostname.toLowerCase();
+    if (IP_RE.test(hostname) || XY_MCDN_RE.test(hostname) ||
+        isMcdnHost(hostname) || isKnownP2pHost(hostname)) {
+      return true;
+    }
+    if (config.portHeuristic && hasNonDefaultPort(url)) {
+      return true;
+    }
+    return typeof extra === "string" && /(?:^|[?&])os=mcdn(?:&|$)/i.test(extra);
+  }
+
+  // Drop PCDN/MCDN entries from live url_info host lists, keeping the official
+  // CDN entries the player can fail over to. Never removes the last usable host:
+  // if every entry looks slow, the list is left untouched. Returns rewrite-shaped
+  // entries ({original, url, reason}) so callers can log them like URL rewrites.
+  function filterLiveUrlInfo(payload, rawConfig, depth, seen) {
+    const config = normalizeConfig(rawConfig);
+    const level = depth || 0;
+    const visited = seen || new WeakSet();
+    const result = { changed: false, rewrites: [] };
+
+    if (!config.enabled || config.mode === "off" ||
+        payload == null || typeof payload !== "object" ||
+        level > config.maxDepth || visited.has(payload)) {
+      return result;
+    }
+    visited.add(payload);
+
+    const list = payload.url_info;
+    if (Array.isArray(list) && list.length > 1 &&
+        list.every(function (item) { return item && typeof item.host === "string"; })) {
+      const kept = list.filter(function (item) {
+        return !isSlowLiveHost(item.host, item.extra, config);
+      });
+      if (kept.length > 0 && kept.length < list.length) {
+        list.forEach(function (item) {
+          if (kept.indexOf(item) === -1) {
+            result.rewrites.push({
+              changed: true,
+              original: item.host,
+              url: kept[0].host,
+              reason: "live-pcdn-filter"
+            });
+          }
+        });
+        list.length = 0;
+        kept.forEach(function (item) { list.push(item); });
+        result.changed = true;
+      }
+    }
+
+    const keys = Array.isArray(payload)
+      ? payload.map(function (_, i) { return i; })
+      : Object.keys(payload);
+    for (let i = 0; i < keys.length; i += 1) {
+      const child = filterLiveUrlInfo(payload[keys[i]], config, level + 1, visited);
+      if (child.changed) {
+        result.changed = true;
+        result.rewrites = result.rewrites.concat(child.rewrites);
+      }
+    }
+    return result;
+  }
+
   function rewriteJsonText(text, rawConfig) {
     const state = { changed: false, rewrites: [] };
     const parsed = JSON.parse(text);
@@ -478,6 +602,8 @@
     normalizeConfig,
     hasMediaSignal: hasBiliMediaSignal,
     classify,
+    isSlowLiveHost,
+    filterLiveUrlInfo,
     selectTarget,
     alternativesFor,
     throughputMbps,
@@ -501,6 +627,7 @@
   }
   root.__BILI_ACCELERATOR_INSTALLED__ = true;
 
+  const VERSION = "0.2.3";
   const STORAGE_KEY = "biliAccelerator.config.v2";
   const LEGACY_KEY = "biliAccelerator.config.v1";
   const RANK_PREFIX = "biliAccelerator.rank.";
@@ -512,6 +639,8 @@
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const STALL_GRACE_MS = 2500;
+  const STALL_RETRY_MS = 5000;
+  const PROBE_TIMEOUT_MS = 4000;
 
   const nativeJsonParse = JSON.parse;
   const nativeFetch = root.fetch;
@@ -531,6 +660,7 @@
     rewrites: [],
     rewriteCount: 0,
     lastSource: "",
+    lastMediaHost: null,
     status: "idle",
     stalls: 0,
     recoveries: 0,
@@ -669,16 +799,50 @@
     return null;
   }
 
-  // Add host-swapped alternatives to DASH entries so Bilibili's own backupUrl
-  // failover can recover for free if the primary host stalls.
+  function backupPool() {
+    return state.ranking.length ? state.ranking : config.candidatePool;
+  }
+
+  // Merge host-swapped alternatives of `base` into entry[key], deduped, max 8.
+  function mergeBackups(entry, key, base) {
+    const alts = core.alternativesFor(base, config, backupPool());
+    if (!alts.length) {
+      return;
+    }
+    const existing = Array.isArray(entry[key]) ? entry[key] : [];
+    const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
+      return arr.indexOf(u) === i;
+    });
+    entry[key] = merged.slice(0, 8);
+  }
+
+  // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
+  // backup-URL failover can recover for free if the primary host stalls.
+  // Payload shapes: data.dash (web player), result.video_info.dash (bangumi),
+  // result.dash, bare dash; durl carries the legacy FLV/MP4 lists. Web-API DASH
+  // uses camelCase (baseUrl/backupUrl); app-style payloads and durl use
+  // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
       return;
     }
-    const dash = (payload.data && payload.data.dash) ||
-      (payload.result && payload.result.dash) ||
-      payload.dash;
-    if (!dash) {
+    const containers = [
+      payload.data,
+      payload.result,
+      payload.result && payload.result.video_info,
+      payload
+    ];
+    containers.forEach(function eachContainer(container) {
+      if (!container || typeof container !== "object") {
+        return;
+      }
+      enrichDash(container.dash);
+      enrichDurl(container.durl);
+    });
+  }
+
+  function enrichDash(dash) {
+    if (!dash || typeof dash !== "object") {
       return;
     }
     ["video", "audio"].forEach(function eachKind(kind) {
@@ -687,19 +851,27 @@
         return;
       }
       list.forEach(function eachEntry(entry) {
-        if (!entry || typeof entry.baseUrl !== "string") {
+        if (!entry) {
           return;
         }
-        const alts = core.alternativesFor(entry.baseUrl, config, state.ranking.length ? state.ranking : config.candidatePool);
-        if (!alts.length) {
-          return;
+        if (typeof entry.baseUrl === "string") {
+          mergeBackups(entry, "backupUrl", entry.baseUrl);
         }
-        const existing = Array.isArray(entry.backupUrl) ? entry.backupUrl : [];
-        const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
-          return arr.indexOf(u) === i;
-        });
-        entry.backupUrl = merged.slice(0, 8);
+        if (typeof entry.base_url === "string") {
+          mergeBackups(entry, "backup_url", entry.base_url);
+        }
       });
+    });
+  }
+
+  function enrichDurl(durl) {
+    if (!Array.isArray(durl)) {
+      return;
+    }
+    durl.forEach(function eachEntry(entry) {
+      if (entry && typeof entry.url === "string") {
+        mergeBackups(entry, "backup_url", entry.url);
+      }
     });
   }
 
@@ -709,11 +881,25 @@
       const rewritten = core.rewriteObject(payload, config, tracker);
       enrichBackups(rewritten);
       record(tracker.rewrites, source);
+      filterLivePcdn(rewritten, source);
       rememberSample(rewritten);
       return rewritten;
     } catch (error) {
       console.warn("[BiliAccelerator] rewrite failed", error);
       return payload;
+    }
+  }
+
+  // Live playurl payloads list candidate hosts (url_info) instead of full URLs;
+  // drop the PCDN/MCDN entries so the live player only ever dials official CDN.
+  function filterLivePcdn(payload, source) {
+    try {
+      const filtered = core.filterLiveUrlInfo(payload, config);
+      if (filtered.changed) {
+        record(filtered.rewrites, source);
+      }
+    } catch (_) {
+      // never let live filtering break payload delivery.
     }
   }
 
@@ -746,6 +932,13 @@
         ? Object.assign({}, config, { mode: "force" })
         : config;
       const detail = core.rewriteUrlDetail(rawUrl, cfg);
+      // Track which host actually serves the media: the <video> element only
+      // exposes a blob: URL under MSE, so this is what stall recovery must avoid.
+      try {
+        state.lastMediaHost = detail.changed
+          ? new URL(detail.url).hostname
+          : (host || state.lastMediaHost);
+      } catch (_) {}
       if (detail.changed) {
         record([detail], "segment");
         return detail.url;
@@ -759,11 +952,12 @@
   // ---- interception -------------------------------------------------------
 
   function isInterestingFetch(input) {
-    const url = typeof input === "string" ? input : input && input.url;
+    const url = requestUrlOf(input);
     return typeof url === "string" &&
       (url.includes("/x/player") ||
         url.includes("/pgc/player") ||
         url.includes("playurl") ||
+        url.includes("getRoomPlayInfo") ||
         url.includes("bilivideo"));
   }
 
@@ -781,8 +975,11 @@
     if (typeof input === "string") {
       return input;
     }
+    if (input && typeof input.href === "string") {
+      return input.href; // URL instance
+    }
     if (input && typeof input.url === "string") {
-      return input.url;
+      return input.url; // Request instance
     }
     return null;
   }
@@ -798,7 +995,11 @@
       if (config.enabled && isMedia) {
         const swapped = rewriteRequestUrl(reqUrl);
         if (swapped !== reqUrl) {
-          input = typeof input === "string" ? swapped : new Request(swapped, input);
+          // string and URL inputs can be replaced by the string directly; only a
+          // Request needs to be rebuilt to preserve its init options.
+          input = (typeof input === "string" || typeof input.href === "string")
+            ? swapped
+            : new Request(swapped, input);
           args = [input, init];
         }
       }
@@ -828,18 +1029,21 @@
           }
           let parsed;
           const tracker = { changed: false, rewrites: [] };
+          let live = { changed: false, rewrites: [] };
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed) {
+          if (!tracker.changed && !live.changed) {
             rememberSample(parsed);
             return response;
           }
           record(tracker.rewrites, "fetch");
+          record(live.rewrites, "fetch");
           rememberSample(parsed);
           const headers = new Headers(response.headers);
           headers.delete("content-length");
@@ -866,10 +1070,13 @@
     const send = NativeXHR.prototype.send;
 
     NativeXHR.prototype.open = function patchedOpen(method, url) {
-      this.__baAccel = { url: typeof url === "string" ? url : "" };
+      const urlStr = typeof url === "string"
+        ? url
+        : (url && typeof url.href === "string" ? url.href : "");
+      this.__baAccel = { url: urlStr };
       let finalUrl = url;
-      if (config.enabled && typeof url === "string" && core.hasMediaSignal(url)) {
-        finalUrl = rewriteRequestUrl(url);
+      if (config.enabled && urlStr && core.hasMediaSignal(urlStr)) {
+        finalUrl = rewriteRequestUrl(urlStr);
       }
       return open.apply(this, [method, finalUrl].concat([].slice.call(arguments, 2)));
     };
@@ -880,7 +1087,8 @@
       const isMedia = typeof meta.url === "string" && core.hasMediaSignal(meta.url);
       const interesting = typeof meta.url === "string" &&
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
-          meta.url.includes("/pgc/player") || isMedia);
+          meta.url.includes("/pgc/player") || meta.url.includes("getRoomPlayInfo") ||
+          isMedia);
 
       // Count downloaded bytes for media segments (free via loadend.loaded) and
       // time send→loadend as the transfer duration for the throughput window.
@@ -908,8 +1116,9 @@
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed) {
+            if (!tracker.changed && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);
@@ -927,6 +1136,7 @@
               });
             } catch (_) {}
             record(tracker.rewrites, "xhr");
+            record(live.rewrites, "xhr");
           } catch (_) {
             // leave the original response intact on any failure.
           }
@@ -965,6 +1175,22 @@
     if (!config.p2pGuard) {
       return;
     }
+    // Stub Bilibili's P2P SDK entry points so the player never boots the
+    // PCDN/seeder mesh (same surface MBGTEB neutralizes). Instances only need
+    // an `on` no-op to satisfy the player's wiring code.
+    function NoopSdk() {}
+    NoopSdk.prototype.on = function () {};
+    ["PCDNLoader", "BPP2PSDK", "SeederSDK"].forEach(function (name) {
+      try {
+        Object.defineProperty(root, name, {
+          configurable: false,
+          writable: false,
+          value: NoopSdk
+        });
+      } catch (_) {
+        // already defined and frozen; ignore.
+      }
+    });
     ["RTCPeerConnection", "webkitRTCPeerConnection", "mozRTCPeerConnection"].forEach(function (name) {
       try {
         const Blocked = function BlockedRTCPeerConnection() {
@@ -999,28 +1225,55 @@
     }
   }
 
+  // TTFB-probe one candidate host by re-requesting the signed sample URL on it.
+  // Uses cors mode (the CDN sends ACAO for the player's own segment fetches) so
+  // the real status is visible — under no-cors a host that fast-fails with 403
+  // would look "healthy" and win the ranking. No Range header: it isn't
+  // no-cors/preflight-safe everywhere, and the body is aborted right after the
+  // headers arrive anyway, so only a few KB ever transfer.
   function probeHost(host, sampleUrl) {
     const url = swapHost(sampleUrl, host);
     if (!url) {
       return Promise.resolve({ host, ttfb: null, ok: false });
     }
-    const started = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-    const timeout = new Promise(function (resolve) {
-      setTimeout(function () { resolve({ host, ttfb: null, ok: false }); }, 4000);
-    });
-    const probe = nativeFetch(url, {
-      method: "GET",
-      headers: { Range: "bytes=0-1" },
-      mode: "no-cors",
-      cache: "no-store",
-      credentials: "omit"
-    }).then(function () {
-      const now = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-      return { host, ttfb: now - started, ok: true };
+    const started = nowMs();
+    const init = { method: "GET", mode: "cors", cache: "no-store", credentials: "omit" };
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    let timer = null;
+    let settled = false;
+    if (controller) {
+      init.signal = controller.signal;
+      timer = setTimeout(function () { controller.abort(); }, PROBE_TIMEOUT_MS);
+    }
+    const probe = nativeFetch(url, init).then(function (response) {
+      const ttfb = nowMs() - started;
+      // Headers are in — stop the body download, we only wanted the timing.
+      try {
+        if (response.body && typeof response.body.cancel === "function") {
+          response.body.cancel();
+        }
+      } catch (_) {}
+      return { host, ttfb: response.ok ? ttfb : null, ok: !!response.ok };
     }).catch(function () {
       return { host, ttfb: null, ok: false };
+    }).then(function (result) {
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      return result;
     });
-    return Promise.race([probe, timeout]);
+    if (controller) {
+      return probe;
+    }
+    // No AbortController (very old engines): fall back to racing a timeout.
+    return Promise.race([probe, new Promise(function (resolve) {
+      setTimeout(function () {
+        if (!settled) {
+          resolve({ host, ttfb: null, ok: false });
+        }
+      }, PROBE_TIMEOUT_MS);
+    })]);
   }
 
   function scheduleProbe(sampleUrl) {
@@ -1087,11 +1340,18 @@
     if (watchedVideo.readyState >= 3) {
       return;
     }
-    state.stalls += 1;
+    // Count distinct stall episodes once; re-checks of the same episode below
+    // only add recovery rotations.
+    if (state.status !== "buffering") {
+      state.stalls += 1;
+    }
     state.status = "buffering";
     if (config.stallRecovery && config.selection === "auto") {
-      rotateTarget(currentVideoHost());
+      rotateTarget(state.lastMediaHost || currentVideoHost());
       state.recoveries += 1;
+      // Keep rotating while the stall persists — 'waiting' fires only once per
+      // episode, so without a re-check a single bad pick would strand playback.
+      stallTimer = setTimeout(handleStall, STALL_RETRY_MS);
     }
     renderStatus();
   }
@@ -1130,7 +1390,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.2",
+      version: VERSION,
       installedAt: state.installedAt,
       region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
@@ -1223,6 +1483,12 @@
     speed.transfers = speed.transfers.filter(function keep(tr) {
       return tr.end > now - SPEED_WINDOW_MS;
     });
+
+    // Background tabs get throttled timers anyway; skip the series/UI work and
+    // resume cleanly when the tab is visible again.
+    if (document.hidden) {
+      return;
+    }
 
     let playing = false;
     try {
@@ -2217,6 +2483,7 @@
   patchXHR();
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
+  patchGlobalPlayInfo("__NEPTUNE_IS_MY_WAIFU__"); // live room initial state
   installP2PGuard();
   installConfigBridge();
 

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -57,6 +57,35 @@
   const IP_RE = /^(?:\d{1,3}\.){3}\d{1,3}$/;
   const XY_MCDN_RE = /^xy(?:\d+x){3}\d+xy\.mcdn\.bilivideo\.(?:cn|com|net)$/i;
 
+  // P2P/PCDN families known from community research (Bilibili-Evolved, MBGTEB):
+  // szbdyd is the legacy scheduler, mountaintoys the 2025 rename, nexusedgeio and
+  // ahdohpiechei are where the upos-*302* redirect hosts land, and mirror14b is a
+  // mirror-named host that actually serves PCDN (its TLS cert is *.bilivideo.cn).
+  const KNOWN_P2P_SUFFIXES = Object.freeze([
+    ".szbdyd.com",
+    ".mountaintoys.cn",
+    ".nexusedgeio.com",
+    ".ahdohpiechei.com"
+  ]);
+  const KNOWN_P2P_HOSTS = Object.freeze([
+    "upos-sz-mirror14b.bilivideo.com"
+  ]);
+
+  function isKnownP2pHost(hostname) {
+    if (KNOWN_P2P_HOSTS.indexOf(hostname) !== -1) {
+      return true;
+    }
+    for (let i = 0; i < KNOWN_P2P_SUFFIXES.length; i += 1) {
+      if (hostname.length > KNOWN_P2P_SUFFIXES[i].length &&
+          hostname.indexOf(KNOWN_P2P_SUFFIXES[i]) === hostname.length - KNOWN_P2P_SUFFIXES[i].length) {
+        return true;
+      }
+    }
+    // upos-sz-302ppio / upos-sz-302kodo style hosts answer with an HTTP 302 to a
+    // residential P2P node; the "302" only ever appears in that first label.
+    return hostname.indexOf("upos-") === 0 && hostname.split(".")[0].indexOf("302") !== -1;
+  }
+
   // Forward-migrate any stored config (v1 or partial) onto the v2 defaults.
   function normalizeConfig(config) {
     const merged = Object.assign({}, DEFAULT_CONFIG, config || {});
@@ -81,6 +110,9 @@
       (value.includes("bilivideo") ||
         value.includes("akamaized.net") ||
         value.includes("szbdyd.com") ||
+        value.includes("mountaintoys") ||
+        value.includes("nexusedgeio") ||
+        value.includes("ahdohpiechei") ||
         value.includes("mcdn.bili") ||
         value.includes("os=mcdn") ||
         value.includes("/upgcxcode/") ||
@@ -93,7 +125,8 @@
     }
 
     try {
-      const url = new URL(value);
+      // Payloads occasionally carry protocol-relative URLs ("//host/path").
+      const url = new URL(value.slice(0, 2) === "//" ? "https:" + value : value);
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         return null;
       }
@@ -107,6 +140,14 @@
     return MEDIA_PATH_RE.test(url.pathname + url.search) ||
       url.pathname.startsWith("/upgcxcode/") ||
       url.pathname.startsWith("/v1/resource/");
+  }
+
+  // Live streams (/live-bvc/ FLV & HLS) are served by a separate CDN tier — the
+  // VOD upos mirrors and the MCDN proxy cannot serve them, so a host swap or
+  // proxy wrap would hard-break live playback. Live PCDN is handled upstream by
+  // filtering the getRoomPlayInfo host list instead (see filterLiveUrlInfo).
+  function isLiveMediaUrl(url) {
+    return url.pathname.indexOf("/live-bvc/") !== -1;
   }
 
   function isMcdnHost(hostname) {
@@ -154,15 +195,16 @@
     const akamai = hostname.endsWith(".akamaized.net");
     const portPcdn = config.portHeuristic && hasNonDefaultPort(url);
     const queryMcdn = hasMcdnQuery(url);
+    const knownP2p = isKnownP2pHost(hostname);
 
-    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn;
+    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn || knownP2p;
 
     let kind = "unknown";
     if (schedulerSource !== null || hostname.endsWith(".szbdyd.com")) {
       kind = "scheduler";
     } else if (mcdn) {
       kind = "mcdn";
-    } else if (ipLike || xyMcdn || portPcdn || queryMcdn) {
+    } else if (isPcdn) {
       kind = "pcdn";
     } else if (akamai) {
       kind = "akamai";
@@ -233,6 +275,10 @@
       return { changed: false, original, url: original, reason: "ignored" };
     }
 
+    if (isLiveMediaUrl(url)) {
+      return { changed: false, original, url: original, reason: "live-skip" };
+    }
+
     const verdict = classify(url, config);
 
     if (verdict.schedulerSource) {
@@ -282,7 +328,7 @@
   function alternativesFor(value, rawConfig, hosts) {
     const config = normalizeConfig(rawConfig);
     const url = parseUrl(String(value || ""));
-    if (!url || !isMediaUrl(url)) {
+    if (!url || !isMediaUrl(url) || isLiveMediaUrl(url)) {
       return [];
     }
     const pool = (hosts && hosts.length ? hosts : config.candidatePool) || [];
@@ -440,6 +486,84 @@
     return value;
   }
 
+  // Live playurl payloads (getRoomPlayInfo) don't carry full media URLs — each
+  // stream/format/codec entry lists candidate hosts in url_info: [{host, extra}].
+  // A host like "https://xy…xy.mcdn.bilivideo.cn:486" is a residential PCDN node;
+  // slow for overseas viewers. This decides "is this live host slow" from the
+  // same behavioral signals as classify(), minus the media-path requirement.
+  function isSlowLiveHost(hostValue, extra, rawConfig) {
+    const config = normalizeConfig(rawConfig);
+    const raw = String(hostValue || "");
+    let url;
+    try {
+      url = new URL(raw.indexOf("://") !== -1 ? raw : "https://" + raw.replace(/^\/\//, ""));
+    } catch (_) {
+      return false;
+    }
+    const hostname = url.hostname.toLowerCase();
+    if (IP_RE.test(hostname) || XY_MCDN_RE.test(hostname) ||
+        isMcdnHost(hostname) || isKnownP2pHost(hostname)) {
+      return true;
+    }
+    if (config.portHeuristic && hasNonDefaultPort(url)) {
+      return true;
+    }
+    return typeof extra === "string" && /(?:^|[?&])os=mcdn(?:&|$)/i.test(extra);
+  }
+
+  // Drop PCDN/MCDN entries from live url_info host lists, keeping the official
+  // CDN entries the player can fail over to. Never removes the last usable host:
+  // if every entry looks slow, the list is left untouched. Returns rewrite-shaped
+  // entries ({original, url, reason}) so callers can log them like URL rewrites.
+  function filterLiveUrlInfo(payload, rawConfig, depth, seen) {
+    const config = normalizeConfig(rawConfig);
+    const level = depth || 0;
+    const visited = seen || new WeakSet();
+    const result = { changed: false, rewrites: [] };
+
+    if (!config.enabled || config.mode === "off" ||
+        payload == null || typeof payload !== "object" ||
+        level > config.maxDepth || visited.has(payload)) {
+      return result;
+    }
+    visited.add(payload);
+
+    const list = payload.url_info;
+    if (Array.isArray(list) && list.length > 1 &&
+        list.every(function (item) { return item && typeof item.host === "string"; })) {
+      const kept = list.filter(function (item) {
+        return !isSlowLiveHost(item.host, item.extra, config);
+      });
+      if (kept.length > 0 && kept.length < list.length) {
+        list.forEach(function (item) {
+          if (kept.indexOf(item) === -1) {
+            result.rewrites.push({
+              changed: true,
+              original: item.host,
+              url: kept[0].host,
+              reason: "live-pcdn-filter"
+            });
+          }
+        });
+        list.length = 0;
+        kept.forEach(function (item) { list.push(item); });
+        result.changed = true;
+      }
+    }
+
+    const keys = Array.isArray(payload)
+      ? payload.map(function (_, i) { return i; })
+      : Object.keys(payload);
+    for (let i = 0; i < keys.length; i += 1) {
+      const child = filterLiveUrlInfo(payload[keys[i]], config, level + 1, visited);
+      if (child.changed) {
+        result.changed = true;
+        result.rewrites = result.rewrites.concat(child.rewrites);
+      }
+    }
+    return result;
+  }
+
   function rewriteJsonText(text, rawConfig) {
     const state = { changed: false, rewrites: [] };
     const parsed = JSON.parse(text);
@@ -461,6 +585,8 @@
     normalizeConfig,
     hasMediaSignal: hasBiliMediaSignal,
     classify,
+    isSlowLiveHost,
+    filterLiveUrlInfo,
     selectTarget,
     alternativesFor,
     throughputMbps,
@@ -484,6 +610,7 @@
   }
   root.__BILI_ACCELERATOR_INSTALLED__ = true;
 
+  const VERSION = "0.2.3";
   const STORAGE_KEY = "biliAccelerator.config.v2";
   const LEGACY_KEY = "biliAccelerator.config.v1";
   const RANK_PREFIX = "biliAccelerator.rank.";
@@ -495,6 +622,8 @@
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const STALL_GRACE_MS = 2500;
+  const STALL_RETRY_MS = 5000;
+  const PROBE_TIMEOUT_MS = 4000;
 
   const nativeJsonParse = JSON.parse;
   const nativeFetch = root.fetch;
@@ -514,6 +643,7 @@
     rewrites: [],
     rewriteCount: 0,
     lastSource: "",
+    lastMediaHost: null,
     status: "idle",
     stalls: 0,
     recoveries: 0,
@@ -652,16 +782,50 @@
     return null;
   }
 
-  // Add host-swapped alternatives to DASH entries so Bilibili's own backupUrl
-  // failover can recover for free if the primary host stalls.
+  function backupPool() {
+    return state.ranking.length ? state.ranking : config.candidatePool;
+  }
+
+  // Merge host-swapped alternatives of `base` into entry[key], deduped, max 8.
+  function mergeBackups(entry, key, base) {
+    const alts = core.alternativesFor(base, config, backupPool());
+    if (!alts.length) {
+      return;
+    }
+    const existing = Array.isArray(entry[key]) ? entry[key] : [];
+    const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
+      return arr.indexOf(u) === i;
+    });
+    entry[key] = merged.slice(0, 8);
+  }
+
+  // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
+  // backup-URL failover can recover for free if the primary host stalls.
+  // Payload shapes: data.dash (web player), result.video_info.dash (bangumi),
+  // result.dash, bare dash; durl carries the legacy FLV/MP4 lists. Web-API DASH
+  // uses camelCase (baseUrl/backupUrl); app-style payloads and durl use
+  // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
       return;
     }
-    const dash = (payload.data && payload.data.dash) ||
-      (payload.result && payload.result.dash) ||
-      payload.dash;
-    if (!dash) {
+    const containers = [
+      payload.data,
+      payload.result,
+      payload.result && payload.result.video_info,
+      payload
+    ];
+    containers.forEach(function eachContainer(container) {
+      if (!container || typeof container !== "object") {
+        return;
+      }
+      enrichDash(container.dash);
+      enrichDurl(container.durl);
+    });
+  }
+
+  function enrichDash(dash) {
+    if (!dash || typeof dash !== "object") {
       return;
     }
     ["video", "audio"].forEach(function eachKind(kind) {
@@ -670,19 +834,27 @@
         return;
       }
       list.forEach(function eachEntry(entry) {
-        if (!entry || typeof entry.baseUrl !== "string") {
+        if (!entry) {
           return;
         }
-        const alts = core.alternativesFor(entry.baseUrl, config, state.ranking.length ? state.ranking : config.candidatePool);
-        if (!alts.length) {
-          return;
+        if (typeof entry.baseUrl === "string") {
+          mergeBackups(entry, "backupUrl", entry.baseUrl);
         }
-        const existing = Array.isArray(entry.backupUrl) ? entry.backupUrl : [];
-        const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
-          return arr.indexOf(u) === i;
-        });
-        entry.backupUrl = merged.slice(0, 8);
+        if (typeof entry.base_url === "string") {
+          mergeBackups(entry, "backup_url", entry.base_url);
+        }
       });
+    });
+  }
+
+  function enrichDurl(durl) {
+    if (!Array.isArray(durl)) {
+      return;
+    }
+    durl.forEach(function eachEntry(entry) {
+      if (entry && typeof entry.url === "string") {
+        mergeBackups(entry, "backup_url", entry.url);
+      }
     });
   }
 
@@ -692,11 +864,25 @@
       const rewritten = core.rewriteObject(payload, config, tracker);
       enrichBackups(rewritten);
       record(tracker.rewrites, source);
+      filterLivePcdn(rewritten, source);
       rememberSample(rewritten);
       return rewritten;
     } catch (error) {
       console.warn("[BiliAccelerator] rewrite failed", error);
       return payload;
+    }
+  }
+
+  // Live playurl payloads list candidate hosts (url_info) instead of full URLs;
+  // drop the PCDN/MCDN entries so the live player only ever dials official CDN.
+  function filterLivePcdn(payload, source) {
+    try {
+      const filtered = core.filterLiveUrlInfo(payload, config);
+      if (filtered.changed) {
+        record(filtered.rewrites, source);
+      }
+    } catch (_) {
+      // never let live filtering break payload delivery.
     }
   }
 
@@ -729,6 +915,13 @@
         ? Object.assign({}, config, { mode: "force" })
         : config;
       const detail = core.rewriteUrlDetail(rawUrl, cfg);
+      // Track which host actually serves the media: the <video> element only
+      // exposes a blob: URL under MSE, so this is what stall recovery must avoid.
+      try {
+        state.lastMediaHost = detail.changed
+          ? new URL(detail.url).hostname
+          : (host || state.lastMediaHost);
+      } catch (_) {}
       if (detail.changed) {
         record([detail], "segment");
         return detail.url;
@@ -742,11 +935,12 @@
   // ---- interception -------------------------------------------------------
 
   function isInterestingFetch(input) {
-    const url = typeof input === "string" ? input : input && input.url;
+    const url = requestUrlOf(input);
     return typeof url === "string" &&
       (url.includes("/x/player") ||
         url.includes("/pgc/player") ||
         url.includes("playurl") ||
+        url.includes("getRoomPlayInfo") ||
         url.includes("bilivideo"));
   }
 
@@ -764,8 +958,11 @@
     if (typeof input === "string") {
       return input;
     }
+    if (input && typeof input.href === "string") {
+      return input.href; // URL instance
+    }
     if (input && typeof input.url === "string") {
-      return input.url;
+      return input.url; // Request instance
     }
     return null;
   }
@@ -781,7 +978,11 @@
       if (config.enabled && isMedia) {
         const swapped = rewriteRequestUrl(reqUrl);
         if (swapped !== reqUrl) {
-          input = typeof input === "string" ? swapped : new Request(swapped, input);
+          // string and URL inputs can be replaced by the string directly; only a
+          // Request needs to be rebuilt to preserve its init options.
+          input = (typeof input === "string" || typeof input.href === "string")
+            ? swapped
+            : new Request(swapped, input);
           args = [input, init];
         }
       }
@@ -811,18 +1012,21 @@
           }
           let parsed;
           const tracker = { changed: false, rewrites: [] };
+          let live = { changed: false, rewrites: [] };
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed) {
+          if (!tracker.changed && !live.changed) {
             rememberSample(parsed);
             return response;
           }
           record(tracker.rewrites, "fetch");
+          record(live.rewrites, "fetch");
           rememberSample(parsed);
           const headers = new Headers(response.headers);
           headers.delete("content-length");
@@ -849,10 +1053,13 @@
     const send = NativeXHR.prototype.send;
 
     NativeXHR.prototype.open = function patchedOpen(method, url) {
-      this.__baAccel = { url: typeof url === "string" ? url : "" };
+      const urlStr = typeof url === "string"
+        ? url
+        : (url && typeof url.href === "string" ? url.href : "");
+      this.__baAccel = { url: urlStr };
       let finalUrl = url;
-      if (config.enabled && typeof url === "string" && core.hasMediaSignal(url)) {
-        finalUrl = rewriteRequestUrl(url);
+      if (config.enabled && urlStr && core.hasMediaSignal(urlStr)) {
+        finalUrl = rewriteRequestUrl(urlStr);
       }
       return open.apply(this, [method, finalUrl].concat([].slice.call(arguments, 2)));
     };
@@ -863,7 +1070,8 @@
       const isMedia = typeof meta.url === "string" && core.hasMediaSignal(meta.url);
       const interesting = typeof meta.url === "string" &&
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
-          meta.url.includes("/pgc/player") || isMedia);
+          meta.url.includes("/pgc/player") || meta.url.includes("getRoomPlayInfo") ||
+          isMedia);
 
       // Count downloaded bytes for media segments (free via loadend.loaded) and
       // time send→loadend as the transfer duration for the throughput window.
@@ -891,8 +1099,9 @@
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed) {
+            if (!tracker.changed && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);
@@ -910,6 +1119,7 @@
               });
             } catch (_) {}
             record(tracker.rewrites, "xhr");
+            record(live.rewrites, "xhr");
           } catch (_) {
             // leave the original response intact on any failure.
           }
@@ -948,6 +1158,22 @@
     if (!config.p2pGuard) {
       return;
     }
+    // Stub Bilibili's P2P SDK entry points so the player never boots the
+    // PCDN/seeder mesh (same surface MBGTEB neutralizes). Instances only need
+    // an `on` no-op to satisfy the player's wiring code.
+    function NoopSdk() {}
+    NoopSdk.prototype.on = function () {};
+    ["PCDNLoader", "BPP2PSDK", "SeederSDK"].forEach(function (name) {
+      try {
+        Object.defineProperty(root, name, {
+          configurable: false,
+          writable: false,
+          value: NoopSdk
+        });
+      } catch (_) {
+        // already defined and frozen; ignore.
+      }
+    });
     ["RTCPeerConnection", "webkitRTCPeerConnection", "mozRTCPeerConnection"].forEach(function (name) {
       try {
         const Blocked = function BlockedRTCPeerConnection() {
@@ -982,28 +1208,55 @@
     }
   }
 
+  // TTFB-probe one candidate host by re-requesting the signed sample URL on it.
+  // Uses cors mode (the CDN sends ACAO for the player's own segment fetches) so
+  // the real status is visible — under no-cors a host that fast-fails with 403
+  // would look "healthy" and win the ranking. No Range header: it isn't
+  // no-cors/preflight-safe everywhere, and the body is aborted right after the
+  // headers arrive anyway, so only a few KB ever transfer.
   function probeHost(host, sampleUrl) {
     const url = swapHost(sampleUrl, host);
     if (!url) {
       return Promise.resolve({ host, ttfb: null, ok: false });
     }
-    const started = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-    const timeout = new Promise(function (resolve) {
-      setTimeout(function () { resolve({ host, ttfb: null, ok: false }); }, 4000);
-    });
-    const probe = nativeFetch(url, {
-      method: "GET",
-      headers: { Range: "bytes=0-1" },
-      mode: "no-cors",
-      cache: "no-store",
-      credentials: "omit"
-    }).then(function () {
-      const now = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-      return { host, ttfb: now - started, ok: true };
+    const started = nowMs();
+    const init = { method: "GET", mode: "cors", cache: "no-store", credentials: "omit" };
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    let timer = null;
+    let settled = false;
+    if (controller) {
+      init.signal = controller.signal;
+      timer = setTimeout(function () { controller.abort(); }, PROBE_TIMEOUT_MS);
+    }
+    const probe = nativeFetch(url, init).then(function (response) {
+      const ttfb = nowMs() - started;
+      // Headers are in — stop the body download, we only wanted the timing.
+      try {
+        if (response.body && typeof response.body.cancel === "function") {
+          response.body.cancel();
+        }
+      } catch (_) {}
+      return { host, ttfb: response.ok ? ttfb : null, ok: !!response.ok };
     }).catch(function () {
       return { host, ttfb: null, ok: false };
+    }).then(function (result) {
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      return result;
     });
-    return Promise.race([probe, timeout]);
+    if (controller) {
+      return probe;
+    }
+    // No AbortController (very old engines): fall back to racing a timeout.
+    return Promise.race([probe, new Promise(function (resolve) {
+      setTimeout(function () {
+        if (!settled) {
+          resolve({ host, ttfb: null, ok: false });
+        }
+      }, PROBE_TIMEOUT_MS);
+    })]);
   }
 
   function scheduleProbe(sampleUrl) {
@@ -1070,11 +1323,18 @@
     if (watchedVideo.readyState >= 3) {
       return;
     }
-    state.stalls += 1;
+    // Count distinct stall episodes once; re-checks of the same episode below
+    // only add recovery rotations.
+    if (state.status !== "buffering") {
+      state.stalls += 1;
+    }
     state.status = "buffering";
     if (config.stallRecovery && config.selection === "auto") {
-      rotateTarget(currentVideoHost());
+      rotateTarget(state.lastMediaHost || currentVideoHost());
       state.recoveries += 1;
+      // Keep rotating while the stall persists — 'waiting' fires only once per
+      // episode, so without a re-check a single bad pick would strand playback.
+      stallTimer = setTimeout(handleStall, STALL_RETRY_MS);
     }
     renderStatus();
   }
@@ -1113,7 +1373,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.2",
+      version: VERSION,
       installedAt: state.installedAt,
       region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
@@ -1206,6 +1466,12 @@
     speed.transfers = speed.transfers.filter(function keep(tr) {
       return tr.end > now - SPEED_WINDOW_MS;
     });
+
+    // Background tabs get throttled timers anyway; skip the series/UI work and
+    // resume cleanly when the tab is visible again.
+    if (document.hidden) {
+      return;
+    }
 
     let playing = false;
     try {
@@ -2200,6 +2466,7 @@
   patchXHR();
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
+  patchGlobalPlayInfo("__NEPTUNE_IS_MY_WAIFU__"); // live room initial state
   installP2PGuard();
   installConfigBridge();
 

--- a/dist/extension/manifest.json
+++ b/dist/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
   "icons": {},
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-accelerator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Safari-friendly Bilibili playback CDN accelerator.",
   "scripts": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -5,18 +5,23 @@ const root = path.resolve(new URL("..", import.meta.url).pathname);
 const dist = path.join(root, "dist");
 const extensionDist = path.join(dist, "extension");
 
+const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 const core = await readFile(path.join(root, "src/core/rewrite.js"), "utf8");
 const page = await readFile(path.join(root, "src/page/bili-accelerator.page.js"), "utf8");
 const content = await readFile(path.join(root, "src/extension/content.js"), "utf8");
-const manifest = await readFile(path.join(root, "src/extension/manifest.json"), "utf8");
+const manifest = JSON.parse(await readFile(path.join(root, "src/extension/manifest.json"), "utf8"));
 const popupHtml = await readFile(path.join(root, "src/extension/popup.html"), "utf8");
 const popupJs = await readFile(path.join(root, "src/extension/popup.js"), "utf8");
+
+// package.json is the single source of truth for the release version; the page
+// script's VERSION constant is held to it by a unit test.
+manifest.version = pkg.version;
 
 const userscriptHeader = `// ==UserScript==
 // @name         Bilibili Accelerator
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
-// @version      0.2.2
+// @version      ${pkg.version}
 // @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
 // @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
 // @author       realzza
@@ -36,7 +41,7 @@ await mkdir(extensionDist, { recursive: true });
 await writeFile(path.join(dist, "bilibili-accelerator.user.js"), `${userscriptHeader}\n${core}\n${page}\n`);
 await writeFile(path.join(extensionDist, "bili-accelerator.page.js"), `${core}\n${page}\n`);
 await writeFile(path.join(extensionDist, "content.js"), content);
-await writeFile(path.join(extensionDist, "manifest.json"), manifest);
+await writeFile(path.join(extensionDist, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
 await writeFile(path.join(extensionDist, "popup.html"), popupHtml);
 await writeFile(path.join(extensionDist, "popup.js"), popupJs);
 await copyFile(path.join(root, "README.md"), path.join(dist, "README.md")).catch(() => {});

--- a/src/core/rewrite.js
+++ b/src/core/rewrite.js
@@ -57,6 +57,35 @@
   const IP_RE = /^(?:\d{1,3}\.){3}\d{1,3}$/;
   const XY_MCDN_RE = /^xy(?:\d+x){3}\d+xy\.mcdn\.bilivideo\.(?:cn|com|net)$/i;
 
+  // P2P/PCDN families known from community research (Bilibili-Evolved, MBGTEB):
+  // szbdyd is the legacy scheduler, mountaintoys the 2025 rename, nexusedgeio and
+  // ahdohpiechei are where the upos-*302* redirect hosts land, and mirror14b is a
+  // mirror-named host that actually serves PCDN (its TLS cert is *.bilivideo.cn).
+  const KNOWN_P2P_SUFFIXES = Object.freeze([
+    ".szbdyd.com",
+    ".mountaintoys.cn",
+    ".nexusedgeio.com",
+    ".ahdohpiechei.com"
+  ]);
+  const KNOWN_P2P_HOSTS = Object.freeze([
+    "upos-sz-mirror14b.bilivideo.com"
+  ]);
+
+  function isKnownP2pHost(hostname) {
+    if (KNOWN_P2P_HOSTS.indexOf(hostname) !== -1) {
+      return true;
+    }
+    for (let i = 0; i < KNOWN_P2P_SUFFIXES.length; i += 1) {
+      if (hostname.length > KNOWN_P2P_SUFFIXES[i].length &&
+          hostname.indexOf(KNOWN_P2P_SUFFIXES[i]) === hostname.length - KNOWN_P2P_SUFFIXES[i].length) {
+        return true;
+      }
+    }
+    // upos-sz-302ppio / upos-sz-302kodo style hosts answer with an HTTP 302 to a
+    // residential P2P node; the "302" only ever appears in that first label.
+    return hostname.indexOf("upos-") === 0 && hostname.split(".")[0].indexOf("302") !== -1;
+  }
+
   // Forward-migrate any stored config (v1 or partial) onto the v2 defaults.
   function normalizeConfig(config) {
     const merged = Object.assign({}, DEFAULT_CONFIG, config || {});
@@ -81,6 +110,9 @@
       (value.includes("bilivideo") ||
         value.includes("akamaized.net") ||
         value.includes("szbdyd.com") ||
+        value.includes("mountaintoys") ||
+        value.includes("nexusedgeio") ||
+        value.includes("ahdohpiechei") ||
         value.includes("mcdn.bili") ||
         value.includes("os=mcdn") ||
         value.includes("/upgcxcode/") ||
@@ -93,7 +125,8 @@
     }
 
     try {
-      const url = new URL(value);
+      // Payloads occasionally carry protocol-relative URLs ("//host/path").
+      const url = new URL(value.slice(0, 2) === "//" ? "https:" + value : value);
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         return null;
       }
@@ -107,6 +140,14 @@
     return MEDIA_PATH_RE.test(url.pathname + url.search) ||
       url.pathname.startsWith("/upgcxcode/") ||
       url.pathname.startsWith("/v1/resource/");
+  }
+
+  // Live streams (/live-bvc/ FLV & HLS) are served by a separate CDN tier — the
+  // VOD upos mirrors and the MCDN proxy cannot serve them, so a host swap or
+  // proxy wrap would hard-break live playback. Live PCDN is handled upstream by
+  // filtering the getRoomPlayInfo host list instead (see filterLiveUrlInfo).
+  function isLiveMediaUrl(url) {
+    return url.pathname.indexOf("/live-bvc/") !== -1;
   }
 
   function isMcdnHost(hostname) {
@@ -154,15 +195,16 @@
     const akamai = hostname.endsWith(".akamaized.net");
     const portPcdn = config.portHeuristic && hasNonDefaultPort(url);
     const queryMcdn = hasMcdnQuery(url);
+    const knownP2p = isKnownP2pHost(hostname);
 
-    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn;
+    const isPcdn = ipLike || xyMcdn || portPcdn || queryMcdn || knownP2p;
 
     let kind = "unknown";
     if (schedulerSource !== null || hostname.endsWith(".szbdyd.com")) {
       kind = "scheduler";
     } else if (mcdn) {
       kind = "mcdn";
-    } else if (ipLike || xyMcdn || portPcdn || queryMcdn) {
+    } else if (isPcdn) {
       kind = "pcdn";
     } else if (akamai) {
       kind = "akamai";
@@ -233,6 +275,10 @@
       return { changed: false, original, url: original, reason: "ignored" };
     }
 
+    if (isLiveMediaUrl(url)) {
+      return { changed: false, original, url: original, reason: "live-skip" };
+    }
+
     const verdict = classify(url, config);
 
     if (verdict.schedulerSource) {
@@ -282,7 +328,7 @@
   function alternativesFor(value, rawConfig, hosts) {
     const config = normalizeConfig(rawConfig);
     const url = parseUrl(String(value || ""));
-    if (!url || !isMediaUrl(url)) {
+    if (!url || !isMediaUrl(url) || isLiveMediaUrl(url)) {
       return [];
     }
     const pool = (hosts && hosts.length ? hosts : config.candidatePool) || [];
@@ -440,6 +486,84 @@
     return value;
   }
 
+  // Live playurl payloads (getRoomPlayInfo) don't carry full media URLs — each
+  // stream/format/codec entry lists candidate hosts in url_info: [{host, extra}].
+  // A host like "https://xy…xy.mcdn.bilivideo.cn:486" is a residential PCDN node;
+  // slow for overseas viewers. This decides "is this live host slow" from the
+  // same behavioral signals as classify(), minus the media-path requirement.
+  function isSlowLiveHost(hostValue, extra, rawConfig) {
+    const config = normalizeConfig(rawConfig);
+    const raw = String(hostValue || "");
+    let url;
+    try {
+      url = new URL(raw.indexOf("://") !== -1 ? raw : "https://" + raw.replace(/^\/\//, ""));
+    } catch (_) {
+      return false;
+    }
+    const hostname = url.hostname.toLowerCase();
+    if (IP_RE.test(hostname) || XY_MCDN_RE.test(hostname) ||
+        isMcdnHost(hostname) || isKnownP2pHost(hostname)) {
+      return true;
+    }
+    if (config.portHeuristic && hasNonDefaultPort(url)) {
+      return true;
+    }
+    return typeof extra === "string" && /(?:^|[?&])os=mcdn(?:&|$)/i.test(extra);
+  }
+
+  // Drop PCDN/MCDN entries from live url_info host lists, keeping the official
+  // CDN entries the player can fail over to. Never removes the last usable host:
+  // if every entry looks slow, the list is left untouched. Returns rewrite-shaped
+  // entries ({original, url, reason}) so callers can log them like URL rewrites.
+  function filterLiveUrlInfo(payload, rawConfig, depth, seen) {
+    const config = normalizeConfig(rawConfig);
+    const level = depth || 0;
+    const visited = seen || new WeakSet();
+    const result = { changed: false, rewrites: [] };
+
+    if (!config.enabled || config.mode === "off" ||
+        payload == null || typeof payload !== "object" ||
+        level > config.maxDepth || visited.has(payload)) {
+      return result;
+    }
+    visited.add(payload);
+
+    const list = payload.url_info;
+    if (Array.isArray(list) && list.length > 1 &&
+        list.every(function (item) { return item && typeof item.host === "string"; })) {
+      const kept = list.filter(function (item) {
+        return !isSlowLiveHost(item.host, item.extra, config);
+      });
+      if (kept.length > 0 && kept.length < list.length) {
+        list.forEach(function (item) {
+          if (kept.indexOf(item) === -1) {
+            result.rewrites.push({
+              changed: true,
+              original: item.host,
+              url: kept[0].host,
+              reason: "live-pcdn-filter"
+            });
+          }
+        });
+        list.length = 0;
+        kept.forEach(function (item) { list.push(item); });
+        result.changed = true;
+      }
+    }
+
+    const keys = Array.isArray(payload)
+      ? payload.map(function (_, i) { return i; })
+      : Object.keys(payload);
+    for (let i = 0; i < keys.length; i += 1) {
+      const child = filterLiveUrlInfo(payload[keys[i]], config, level + 1, visited);
+      if (child.changed) {
+        result.changed = true;
+        result.rewrites = result.rewrites.concat(child.rewrites);
+      }
+    }
+    return result;
+  }
+
   function rewriteJsonText(text, rawConfig) {
     const state = { changed: false, rewrites: [] };
     const parsed = JSON.parse(text);
@@ -461,6 +585,8 @@
     normalizeConfig,
     hasMediaSignal: hasBiliMediaSignal,
     classify,
+    isSlowLiveHost,
+    filterLiveUrlInfo,
     selectTarget,
     alternativesFor,
     throughputMbps,

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
   "icons": {},
   "permissions": [

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -7,6 +7,7 @@
   }
   root.__BILI_ACCELERATOR_INSTALLED__ = true;
 
+  const VERSION = "0.2.3";
   const STORAGE_KEY = "biliAccelerator.config.v2";
   const LEGACY_KEY = "biliAccelerator.config.v1";
   const RANK_PREFIX = "biliAccelerator.rank.";
@@ -18,6 +19,8 @@
   const REVEAL_HOTZONE = 150;
   const REVEAL_TIMEOUT = 2600;
   const STALL_GRACE_MS = 2500;
+  const STALL_RETRY_MS = 5000;
+  const PROBE_TIMEOUT_MS = 4000;
 
   const nativeJsonParse = JSON.parse;
   const nativeFetch = root.fetch;
@@ -37,6 +40,7 @@
     rewrites: [],
     rewriteCount: 0,
     lastSource: "",
+    lastMediaHost: null,
     status: "idle",
     stalls: 0,
     recoveries: 0,
@@ -175,16 +179,50 @@
     return null;
   }
 
-  // Add host-swapped alternatives to DASH entries so Bilibili's own backupUrl
-  // failover can recover for free if the primary host stalls.
+  function backupPool() {
+    return state.ranking.length ? state.ranking : config.candidatePool;
+  }
+
+  // Merge host-swapped alternatives of `base` into entry[key], deduped, max 8.
+  function mergeBackups(entry, key, base) {
+    const alts = core.alternativesFor(base, config, backupPool());
+    if (!alts.length) {
+      return;
+    }
+    const existing = Array.isArray(entry[key]) ? entry[key] : [];
+    const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
+      return arr.indexOf(u) === i;
+    });
+    entry[key] = merged.slice(0, 8);
+  }
+
+  // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
+  // backup-URL failover can recover for free if the primary host stalls.
+  // Payload shapes: data.dash (web player), result.video_info.dash (bangumi),
+  // result.dash, bare dash; durl carries the legacy FLV/MP4 lists. Web-API DASH
+  // uses camelCase (baseUrl/backupUrl); app-style payloads and durl use
+  // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
       return;
     }
-    const dash = (payload.data && payload.data.dash) ||
-      (payload.result && payload.result.dash) ||
-      payload.dash;
-    if (!dash) {
+    const containers = [
+      payload.data,
+      payload.result,
+      payload.result && payload.result.video_info,
+      payload
+    ];
+    containers.forEach(function eachContainer(container) {
+      if (!container || typeof container !== "object") {
+        return;
+      }
+      enrichDash(container.dash);
+      enrichDurl(container.durl);
+    });
+  }
+
+  function enrichDash(dash) {
+    if (!dash || typeof dash !== "object") {
       return;
     }
     ["video", "audio"].forEach(function eachKind(kind) {
@@ -193,19 +231,27 @@
         return;
       }
       list.forEach(function eachEntry(entry) {
-        if (!entry || typeof entry.baseUrl !== "string") {
+        if (!entry) {
           return;
         }
-        const alts = core.alternativesFor(entry.baseUrl, config, state.ranking.length ? state.ranking : config.candidatePool);
-        if (!alts.length) {
-          return;
+        if (typeof entry.baseUrl === "string") {
+          mergeBackups(entry, "backupUrl", entry.baseUrl);
         }
-        const existing = Array.isArray(entry.backupUrl) ? entry.backupUrl : [];
-        const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
-          return arr.indexOf(u) === i;
-        });
-        entry.backupUrl = merged.slice(0, 8);
+        if (typeof entry.base_url === "string") {
+          mergeBackups(entry, "backup_url", entry.base_url);
+        }
       });
+    });
+  }
+
+  function enrichDurl(durl) {
+    if (!Array.isArray(durl)) {
+      return;
+    }
+    durl.forEach(function eachEntry(entry) {
+      if (entry && typeof entry.url === "string") {
+        mergeBackups(entry, "backup_url", entry.url);
+      }
     });
   }
 
@@ -215,11 +261,25 @@
       const rewritten = core.rewriteObject(payload, config, tracker);
       enrichBackups(rewritten);
       record(tracker.rewrites, source);
+      filterLivePcdn(rewritten, source);
       rememberSample(rewritten);
       return rewritten;
     } catch (error) {
       console.warn("[BiliAccelerator] rewrite failed", error);
       return payload;
+    }
+  }
+
+  // Live playurl payloads list candidate hosts (url_info) instead of full URLs;
+  // drop the PCDN/MCDN entries so the live player only ever dials official CDN.
+  function filterLivePcdn(payload, source) {
+    try {
+      const filtered = core.filterLiveUrlInfo(payload, config);
+      if (filtered.changed) {
+        record(filtered.rewrites, source);
+      }
+    } catch (_) {
+      // never let live filtering break payload delivery.
     }
   }
 
@@ -252,6 +312,13 @@
         ? Object.assign({}, config, { mode: "force" })
         : config;
       const detail = core.rewriteUrlDetail(rawUrl, cfg);
+      // Track which host actually serves the media: the <video> element only
+      // exposes a blob: URL under MSE, so this is what stall recovery must avoid.
+      try {
+        state.lastMediaHost = detail.changed
+          ? new URL(detail.url).hostname
+          : (host || state.lastMediaHost);
+      } catch (_) {}
       if (detail.changed) {
         record([detail], "segment");
         return detail.url;
@@ -265,11 +332,12 @@
   // ---- interception -------------------------------------------------------
 
   function isInterestingFetch(input) {
-    const url = typeof input === "string" ? input : input && input.url;
+    const url = requestUrlOf(input);
     return typeof url === "string" &&
       (url.includes("/x/player") ||
         url.includes("/pgc/player") ||
         url.includes("playurl") ||
+        url.includes("getRoomPlayInfo") ||
         url.includes("bilivideo"));
   }
 
@@ -287,8 +355,11 @@
     if (typeof input === "string") {
       return input;
     }
+    if (input && typeof input.href === "string") {
+      return input.href; // URL instance
+    }
     if (input && typeof input.url === "string") {
-      return input.url;
+      return input.url; // Request instance
     }
     return null;
   }
@@ -304,7 +375,11 @@
       if (config.enabled && isMedia) {
         const swapped = rewriteRequestUrl(reqUrl);
         if (swapped !== reqUrl) {
-          input = typeof input === "string" ? swapped : new Request(swapped, input);
+          // string and URL inputs can be replaced by the string directly; only a
+          // Request needs to be rebuilt to preserve its init options.
+          input = (typeof input === "string" || typeof input.href === "string")
+            ? swapped
+            : new Request(swapped, input);
           args = [input, init];
         }
       }
@@ -334,18 +409,21 @@
           }
           let parsed;
           const tracker = { changed: false, rewrites: [] };
+          let live = { changed: false, rewrites: [] };
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed) {
+          if (!tracker.changed && !live.changed) {
             rememberSample(parsed);
             return response;
           }
           record(tracker.rewrites, "fetch");
+          record(live.rewrites, "fetch");
           rememberSample(parsed);
           const headers = new Headers(response.headers);
           headers.delete("content-length");
@@ -372,10 +450,13 @@
     const send = NativeXHR.prototype.send;
 
     NativeXHR.prototype.open = function patchedOpen(method, url) {
-      this.__baAccel = { url: typeof url === "string" ? url : "" };
+      const urlStr = typeof url === "string"
+        ? url
+        : (url && typeof url.href === "string" ? url.href : "");
+      this.__baAccel = { url: urlStr };
       let finalUrl = url;
-      if (config.enabled && typeof url === "string" && core.hasMediaSignal(url)) {
-        finalUrl = rewriteRequestUrl(url);
+      if (config.enabled && urlStr && core.hasMediaSignal(urlStr)) {
+        finalUrl = rewriteRequestUrl(urlStr);
       }
       return open.apply(this, [method, finalUrl].concat([].slice.call(arguments, 2)));
     };
@@ -386,7 +467,8 @@
       const isMedia = typeof meta.url === "string" && core.hasMediaSignal(meta.url);
       const interesting = typeof meta.url === "string" &&
         (meta.url.includes("playurl") || meta.url.includes("/x/player") ||
-          meta.url.includes("/pgc/player") || isMedia);
+          meta.url.includes("/pgc/player") || meta.url.includes("getRoomPlayInfo") ||
+          isMedia);
 
       // Count downloaded bytes for media segments (free via loadend.loaded) and
       // time send→loadend as the transfer duration for the throughput window.
@@ -414,8 +496,9 @@
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
             enrichBackups(parsed);
+            const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed) {
+            if (!tracker.changed && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);
@@ -433,6 +516,7 @@
               });
             } catch (_) {}
             record(tracker.rewrites, "xhr");
+            record(live.rewrites, "xhr");
           } catch (_) {
             // leave the original response intact on any failure.
           }
@@ -471,6 +555,22 @@
     if (!config.p2pGuard) {
       return;
     }
+    // Stub Bilibili's P2P SDK entry points so the player never boots the
+    // PCDN/seeder mesh (same surface MBGTEB neutralizes). Instances only need
+    // an `on` no-op to satisfy the player's wiring code.
+    function NoopSdk() {}
+    NoopSdk.prototype.on = function () {};
+    ["PCDNLoader", "BPP2PSDK", "SeederSDK"].forEach(function (name) {
+      try {
+        Object.defineProperty(root, name, {
+          configurable: false,
+          writable: false,
+          value: NoopSdk
+        });
+      } catch (_) {
+        // already defined and frozen; ignore.
+      }
+    });
     ["RTCPeerConnection", "webkitRTCPeerConnection", "mozRTCPeerConnection"].forEach(function (name) {
       try {
         const Blocked = function BlockedRTCPeerConnection() {
@@ -505,28 +605,55 @@
     }
   }
 
+  // TTFB-probe one candidate host by re-requesting the signed sample URL on it.
+  // Uses cors mode (the CDN sends ACAO for the player's own segment fetches) so
+  // the real status is visible — under no-cors a host that fast-fails with 403
+  // would look "healthy" and win the ranking. No Range header: it isn't
+  // no-cors/preflight-safe everywhere, and the body is aborted right after the
+  // headers arrive anyway, so only a few KB ever transfer.
   function probeHost(host, sampleUrl) {
     const url = swapHost(sampleUrl, host);
     if (!url) {
       return Promise.resolve({ host, ttfb: null, ok: false });
     }
-    const started = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-    const timeout = new Promise(function (resolve) {
-      setTimeout(function () { resolve({ host, ttfb: null, ok: false }); }, 4000);
-    });
-    const probe = nativeFetch(url, {
-      method: "GET",
-      headers: { Range: "bytes=0-1" },
-      mode: "no-cors",
-      cache: "no-store",
-      credentials: "omit"
-    }).then(function () {
-      const now = (root.performance && root.performance.now) ? root.performance.now() : Date.now();
-      return { host, ttfb: now - started, ok: true };
+    const started = nowMs();
+    const init = { method: "GET", mode: "cors", cache: "no-store", credentials: "omit" };
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    let timer = null;
+    let settled = false;
+    if (controller) {
+      init.signal = controller.signal;
+      timer = setTimeout(function () { controller.abort(); }, PROBE_TIMEOUT_MS);
+    }
+    const probe = nativeFetch(url, init).then(function (response) {
+      const ttfb = nowMs() - started;
+      // Headers are in — stop the body download, we only wanted the timing.
+      try {
+        if (response.body && typeof response.body.cancel === "function") {
+          response.body.cancel();
+        }
+      } catch (_) {}
+      return { host, ttfb: response.ok ? ttfb : null, ok: !!response.ok };
     }).catch(function () {
       return { host, ttfb: null, ok: false };
+    }).then(function (result) {
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      return result;
     });
-    return Promise.race([probe, timeout]);
+    if (controller) {
+      return probe;
+    }
+    // No AbortController (very old engines): fall back to racing a timeout.
+    return Promise.race([probe, new Promise(function (resolve) {
+      setTimeout(function () {
+        if (!settled) {
+          resolve({ host, ttfb: null, ok: false });
+        }
+      }, PROBE_TIMEOUT_MS);
+    })]);
   }
 
   function scheduleProbe(sampleUrl) {
@@ -593,11 +720,18 @@
     if (watchedVideo.readyState >= 3) {
       return;
     }
-    state.stalls += 1;
+    // Count distinct stall episodes once; re-checks of the same episode below
+    // only add recovery rotations.
+    if (state.status !== "buffering") {
+      state.stalls += 1;
+    }
     state.status = "buffering";
     if (config.stallRecovery && config.selection === "auto") {
-      rotateTarget(currentVideoHost());
+      rotateTarget(state.lastMediaHost || currentVideoHost());
       state.recoveries += 1;
+      // Keep rotating while the stall persists — 'waiting' fires only once per
+      // episode, so without a re-check a single bad pick would strand playback.
+      stallTimer = setTimeout(handleStall, STALL_RETRY_MS);
     }
     renderStatus();
   }
@@ -636,7 +770,7 @@
 
   function buildDiagnostics() {
     return {
-      version: "0.2.2",
+      version: VERSION,
       installedAt: state.installedAt,
       region: regionKey().split("|")[0],   // timezone only — drop locale
       config,
@@ -729,6 +863,12 @@
     speed.transfers = speed.transfers.filter(function keep(tr) {
       return tr.end > now - SPEED_WINDOW_MS;
     });
+
+    // Background tabs get throttled timers anyway; skip the series/UI work and
+    // resume cleanly when the tab is visible again.
+    if (document.hidden) {
+      return;
+    }
 
     let playing = false;
     try {
@@ -1723,6 +1863,7 @@
   patchXHR();
   patchGlobalPlayInfo("__playinfo__");
   patchGlobalPlayInfo("__INITIAL_STATE__");
+  patchGlobalPlayInfo("__NEPTUNE_IS_MY_WAIFU__"); // live room initial state
   installP2PGuard();
   installConfigBridge();
 

--- a/test/page-smoke.test.js
+++ b/test/page-smoke.test.js
@@ -32,7 +32,9 @@ test("page script rewrites playurl JSON parsed by the page", () => {
   const sandbox = {
     URL,
     Date,
-    JSON,
+    // Own JSON facade — the page script patches JSON.parse in place and must
+    // not touch the test runner's global JSON.
+    JSON: { parse: JSON.parse, stringify: JSON.stringify },
     WeakSet,
     Headers,
     Response,

--- a/test/v2-core.test.js
+++ b/test/v2-core.test.js
@@ -62,9 +62,18 @@ test("mountaintoys-style PCDN URL is rewritten to the target host", () => {
 });
 
 test("port heuristic can be disabled", () => {
-  const url = new URL("https://node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?abc=1");
+  // A bcache-style host on an odd port: with the heuristic off it must pass.
+  // (mountaintoys can no longer serve here — it is a known P2P family and is
+  // flagged regardless of port; see the known-suffix tests.)
+  const url = new URL("https://cn-sccd-cu-01-01.bilivideo.com:4830/upgcxcode/v.m4s?abc=1");
   const v = core.classify(url, { portHeuristic: false });
   assert.equal(v.isPcdn, false);
+});
+
+test("known P2P families are flagged even with the port heuristic off", () => {
+  const url = new URL("https://node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?abc=1");
+  const v = core.classify(url, { portHeuristic: false });
+  assert.equal(v.isPcdn, true);
 });
 
 test("os=mcdn alone (no weird port) is treated as PCDN", () => {

--- a/test/v2-page.test.js
+++ b/test/v2-page.test.js
@@ -17,7 +17,11 @@ function loadPage() {
 
   const store = new Map();
   const sandbox = {
-    URL, Date, JSON, WeakSet, Headers, Response, Request, Promise, Math,
+    // Each sandbox gets its own JSON object: the page script patches JSON.parse
+    // in place, and handing it the host realm's JSON would stack patches across
+    // tests (and patch the test runner's own JSON).
+    JSON: { parse: JSON.parse, stringify: JSON.stringify },
+    URL, Date, WeakSet, Headers, Response, Request, Promise, Math,
     setTimeout, clearTimeout, setInterval, Intl,
     performance: { now: () => 1 },
     XMLHttpRequest: FakeXHR,
@@ -101,6 +105,61 @@ test("public API exposes diagnostics and config control", () => {
   const cfg = sandbox.BiliAccelerator.setConfig({ p2pGuard: true });
   assert.equal(cfg.p2pGuard, true);
   const diag = sandbox.BiliAccelerator.getDiagnostics();
-  assert.equal(diag.version, "0.2.2");
+  assert.equal(diag.version, require("../package.json").version,
+    "page VERSION constant must match package.json (single source of truth)");
   assert.ok(diag.counters && typeof diag.counters.rewrites === "number");
+});
+
+test("XHR open() accepts URL objects and still rewrites PCDN segments", () => {
+  const sandbox = loadPage();
+  const xhr = new sandbox.XMLHttpRequest();
+  const bad = new URL("https://node-7.edge.mountaintoys.cn:4830/upgcxcode/12/34/567-1-30280.m4s?os=mcdn&abc=1");
+  xhr.open("GET", bad);
+  assert.equal(new URL(xhr._url).hostname, "upos-sz-mirrorcos.bilivideo.com");
+});
+
+test("live getRoomPlayInfo parsed by the page gets its PCDN hosts filtered", () => {
+  const sandbox = loadPage();
+  const parsed = sandbox.JSON.parse(JSON.stringify({
+    code: 0,
+    data: { playurl_info: { playurl: { stream: [{ format: [{ codec: [{
+      base_url: "/live-bvc/123/live_1234.flv?sig=abc",
+      url_info: [
+        { host: "https://xy36x110x213x230xy.mcdn.bilivideo.cn:486", extra: "?os=mcdn" },
+        { host: "https://d1--cn-gotcha208.bilivideo.com", extra: "?sig=1" }
+      ]
+    }] }] }] } } }
+  }));
+  const urlInfo = parsed.data.playurl_info.playurl.stream[0].format[0].codec[0].url_info;
+  assert.equal(urlInfo.length, 1);
+  assert.equal(urlInfo[0].host, "https://d1--cn-gotcha208.bilivideo.com");
+  assert.ok(sandbox.BiliAccelerator.getStats().rewriteCount >= 1);
+});
+
+test("live segment URLs pass through untouched (no VOD host swap)", () => {
+  const sandbox = loadPage();
+  const xhr = new sandbox.XMLHttpRequest();
+  const liveUrl = "https://xy1x2x3x4xy.mcdn.bilivideo.cn:486/live-bvc/123/live_1234.flv?os=mcdn";
+  xhr.open("GET", liveUrl);
+  assert.equal(xhr._url, liveUrl);
+});
+
+test("bangumi video_info.dash gets backup fan-out; durl gets backup_url fan-out", () => {
+  const sandbox = loadPage();
+  const bangumi = sandbox.JSON.parse(JSON.stringify({
+    result: { video_info: { dash: { video: [{
+      baseUrl: "https://node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?os=mcdn",
+      backupUrl: []
+    }] } } }
+  }));
+  const entry = bangumi.result.video_info.dash.video[0];
+  assert.equal(new URL(entry.baseUrl).hostname, "upos-sz-mirrorcos.bilivideo.com");
+  assert.ok(entry.backupUrl.length > 0);
+
+  const durl = sandbox.JSON.parse(JSON.stringify({
+    data: { durl: [{ url: "https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/v.mp4?x=1" }] }
+  }));
+  const durlEntry = durl.data.durl[0];
+  assert.ok(Array.isArray(durlEntry.backup_url) && durlEntry.backup_url.length > 0);
+  assert.ok(durlEntry.backup_url.every((u) => u.includes("/upgcxcode/v.mp4")));
 });

--- a/test/v3-hardening.test.js
+++ b/test/v3-hardening.test.js
@@ -1,0 +1,125 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const core = require("../src/core/rewrite");
+
+// ---- new PCDN family detection ----------------------------------------------
+
+test("upos-*302* redirect hosts are classified as PCDN", () => {
+  const url = new URL("https://upos-sz-302ppio.bilivideo.com/upgcxcode/12/34/567/567-1-30280.m4s?e=sig");
+  const v = core.classify(url, {});
+  assert.equal(v.isPcdn, true);
+  assert.equal(v.isSlow, true);
+  assert.equal(v.kind, "pcdn");
+});
+
+test("known residential P2P suffixes are PCDN even on default ports", () => {
+  ["https://node.nexusedgeio.com/upgcxcode/v.m4s?x=1",
+    "https://node.ahdohpiechei.com/upgcxcode/v.m4s?x=1",
+    "https://node-7.edge.mountaintoys.cn/upgcxcode/v.m4s?x=1"
+  ].forEach((raw) => {
+    const detail = core.rewriteUrlDetail(raw, {});
+    assert.equal(detail.changed, true, `${raw} should be rewritten`);
+    assert.equal(detail.reason, "pcdn-host");
+  });
+});
+
+test("mirror14b (PCDN with a mirror name) is rewritten", () => {
+  const detail = core.rewriteUrlDetail("https://upos-sz-mirror14b.bilivideo.com/upgcxcode/v.m4s?x=1");
+  assert.equal(detail.changed, true);
+});
+
+test("healthy gotcha-numbered hosts are not tripped by the 302 rule", () => {
+  const url = new URL("https://d1--cn-gotcha208.bilivideo.com/live-bvc/x/index.m3u8?x=1");
+  const v = core.classify(url, {});
+  assert.equal(v.isPcdn, false);
+});
+
+// ---- protocol-relative URLs ---------------------------------------------------
+
+test("protocol-relative media URLs are parsed and rewritten", () => {
+  const detail = core.rewriteUrlDetail("//node-7.edge.mountaintoys.cn:4830/upgcxcode/v.m4s?os=mcdn");
+  assert.equal(detail.changed, true);
+  assert.equal(new URL(detail.url).protocol, "https:");
+  assert.equal(new URL(detail.url).hostname, "upos-sz-mirrorcos.bilivideo.com");
+});
+
+// ---- live-stream safety -------------------------------------------------------
+
+test("live /live-bvc/ URLs are never host-swapped or proxied", () => {
+  // Even an unmistakable PCDN live URL must be left alone: VOD upos mirrors and
+  // the MCDN proxy cannot serve live-bvc paths, so a rewrite hard-breaks live.
+  const pcdnLive = "https://xy1x2x3x4xy.mcdn.bilivideo.cn:486/live-bvc/123/live_1234.flv?os=mcdn&x=1";
+  const detail = core.rewriteUrlDetail(pcdnLive, {});
+  assert.equal(detail.changed, false);
+  assert.equal(detail.reason, "live-skip");
+});
+
+test("alternativesFor never fans out live URLs to VOD hosts", () => {
+  const alts = core.alternativesFor(
+    "https://cn-hk-eq-01-11.bilivideo.com/live-bvc/123/live_1234.m3u8?x=1", {});
+  assert.deepEqual(alts, []);
+});
+
+// ---- live url_info filtering --------------------------------------------------
+
+function livePayload() {
+  return {
+    code: 0,
+    data: {
+      playurl_info: {
+        playurl: {
+          stream: [{
+            format: [{
+              codec: [{
+                base_url: "/live-bvc/123/live_1234.flv?sig=abc",
+                url_info: [
+                  { host: "https://xy36x110x213x230xy.mcdn.bilivideo.cn:486", extra: "?os=mcdn" },
+                  { host: "https://d1--cn-gotcha208.bilivideo.com", extra: "?sig=1" },
+                  { host: "https://cn-hk-eq-01-11.bilivideo.com", extra: "?sig=2" }
+                ]
+              }]
+            }]
+          }]
+        }
+      }
+    }
+  };
+}
+
+test("filterLiveUrlInfo drops PCDN/MCDN hosts and keeps official CDN entries", () => {
+  const payload = livePayload();
+  const result = core.filterLiveUrlInfo(payload, {});
+  assert.equal(result.changed, true);
+  assert.equal(result.rewrites.length, 1);
+  assert.equal(result.rewrites[0].reason, "live-pcdn-filter");
+  const urlInfo = payload.data.playurl_info.playurl.stream[0].format[0].codec[0].url_info;
+  assert.equal(urlInfo.length, 2);
+  assert.ok(urlInfo.every((u) => !u.host.includes("mcdn")));
+});
+
+test("filterLiveUrlInfo never removes the last usable host", () => {
+  const payload = {
+    url_info: [
+      { host: "https://xy1x2x3x4xy.mcdn.bilivideo.cn:486", extra: "?os=mcdn" },
+      { host: "https://5.6.7.8:9000", extra: "" }
+    ]
+  };
+  const result = core.filterLiveUrlInfo(payload, {});
+  assert.equal(result.changed, false);
+  assert.equal(payload.url_info.length, 2);
+});
+
+test("isSlowLiveHost flags mcdn/port/os=mcdn hosts and passes official CDN", () => {
+  assert.equal(core.isSlowLiveHost("https://xy1x2x3x4xy.mcdn.bilivideo.cn:486", "", {}), true);
+  assert.equal(core.isSlowLiveHost("https://cn-gd-ct-01-01.bilivideo.com:9000", "", {}), true);
+  assert.equal(core.isSlowLiveHost("https://d1--cn-gotcha208.bilivideo.com", "?os=mcdn", {}), true);
+  assert.equal(core.isSlowLiveHost("https://d1--cn-gotcha208.bilivideo.com", "?sig=1", {}), false);
+  assert.equal(core.isSlowLiveHost("https://cn-hk-eq-01-11.bilivideo.com", "", {}), false);
+});
+
+test("filterLiveUrlInfo is disabled when the accelerator is off", () => {
+  const payload = livePayload();
+  const result = core.filterLiveUrlInfo(payload, { mode: "off" });
+  assert.equal(result.changed, false);
+  assert.equal(payload.data.playurl_info.playurl.stream[0].format[0].codec[0].url_info.length, 3);
+});


### PR DESCRIPTION
## Why

I audited the whole pipeline against how Bilibili's CDN behaves in mid-2026 (community sources: Bilibili-Evolved discussions, SukkaW/Make-Bilibili-Great-Than-Ever-Before, CCB, whatwg/fetch spec) and found three real correctness problems plus a set of coverage gaps. This is a hardening release — no UI changes.

## The three bugs

### 1. The script could break live streams
`*.bilibili.com` includes `live.bilibili.com`, and live PCDN URLs (`xy…xy.mcdn.bilivideo.cn:486/live-bvc/….flv`) trip every "slow host" heuristic — so they'd be proxied through the **VOD** MCDN proxy or host-swapped to a **VOD** upos mirror. Neither can serve `/live-bvc/`, so the rewrite kills the stream.

**Fix:** live media URLs are never rewritten (`live-skip`). Live acceleration instead happens where the community converged: PCDN/MCDN entries are filtered out of `getRoomPlayInfo`'s `url_info` host lists (covered on fetch, XHR, and the `__NEPTUNE_IS_MY_WAIFU__` global), keeping official CDN entries and never removing the last usable host.

### 2. Probing downloaded full segments and could crown a dead host
`Range` is **not** a no-cors-safelisted header ([whatwg/fetch#1767](https://github.com/whatwg/fetch/issues/1767)), so the old probe's `Range: bytes=0-1` was silently stripped — every probe pulled a **full media segment from 5 hosts in parallel**. Worse, opaque no-cors responses hide the status, so a host that fast-fails with 403 posts the best TTFB and wins the ranking.

**Fix:** probes run in `cors` mode (readable status — a failing host now sinks) with an `AbortController`, canceling the body right after the headers arrive and actually aborting on timeout. **Verified live** from a real Bilibili video page: the test video's playinfo returned `upos-sz-mirrorcosov` (the slow overseas mirror — the problem is real on this network), and all candidate upos hosts answered cross-host signed requests with readable `200`s in cors mode, body cancel OK.

### 3. Stall recovery avoided the wrong host and gave up after one try
Under MSE, `video.currentSrc` is a `blob:` URL, so "avoid the stalling host" never knew the real host. And `waiting` fires once per stall episode, so recovery rotated exactly once even if the new pick was also bad.

**Fix:** the fetch/XHR layer records the host that actually serves media; recovery avoids that. While a stall persists, rotation re-checks every 5s (distinct stalls still counted once).

## Detection & coverage additions

- **New PCDN families** flagged regardless of port: `upos-*302*` redirect hosts and the residential domains they land on (`.nexusedgeio.com`, `.ahdohpiechei.com`), `.mountaintoys.cn` explicitly, and `upos-sz-mirror14b` (PCDN behind a mirror name).
- **`fetch(new URL(…))` / `xhr.open(method, new URL(…))`** were invisible to interception; now handled.
- **Protocol-relative** (`//host/path`) media URLs now parse and rewrite.
- **Backup fan-out** now covers bangumi `result.video_info.dash`, snake_case `base_url`/`backup_url`, and legacy `durl` playlists (live `durl` is exempt).
- **Bandwidth guard** (still opt-in) also stubs `PCDNLoader` / `BPP2PSDK` / `SeederSDK`.

## Hygiene

- **Version single-sourcing:** `package.json` drives the userscript header + manifest at build; a test pins the page `VERSION` constant to it.
- **CI:** GitHub Actions runs tests, builds, and fails if `dist/` drifts from `src/`.
- **Test-harness fix:** sandboxes shared (and patched!) the test runner's global `JSON.parse`, stacking page-script patches across tests — each sandbox now gets its own JSON facade.
- Speed meter skips series/UI work in hidden tabs.

## Tests

48 tests pass (was 32): new coverage for every item above — live-skip, `url_info` filtering (incl. never-orphan and off-mode), 302/known-suffix classification, URL-object rewriting, bangumi/durl fan-out, version sync.

## Release checklist (after merge — awaiting go-ahead)

- [ ] Tag `v0.2.3` + GitHub release
- [ ] Update Greasy Fork listing with `dist/bilibili-accelerator.user.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)