### PR TITLE
docs: remove playback-mechanism details from user-facing copy

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,9 +2,9 @@
 
 [中文](./README.md) · [Greasy Fork](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) · v0.3.0
 
-Watching Bilibili from outside mainland China, popular videos are usually fine. Everything else tends to land on a slow overseas mirror or an MCDN/PCDN node, and then it buffers every few seconds.
+Watching Bilibili from outside mainland China, popular videos are usually fine. Everything else tends to stutter — smooth one moment, buffering the next.
 
-This userscript does one thing: before the player fetches a segment, it swaps those bad playback URLs for healthier official CDN hosts. Healthy CDN traffic is left alone.
+This userscript is meant to smooth that out. It watches playback in the browser, adjusts automatically when a connection is clearly unstable, and shows your live download speed in a panel. When playback is fine, it stays out of the way.
 
 | ☀️ Light | 🌙 Dark |
 | :---: | :---: |
@@ -40,38 +40,13 @@ npm run build
 
 Open `chrome://extensions`, turn on Developer mode, and load `dist/extension`.
 
-## What it actually does
-
-Bilibili returns several signed playback URLs for the same video. Overseas, the problematic ones look like this:
-
-```text
-upos-sz-mirrorcosov.bilivideo.com
-xy153x35x231x78xy.mcdn.bilivideo.cn:8082
-```
-
-The script spots them before the request goes out and rewrites them to something like:
-
-```text
-upos-sz-mirrorcos.bilivideo.com
-proxy-tf-all-ws.bilivideo.com
-```
-
-Detection isn't a hand-maintained domain blocklist. Odd ports, `os=mcdn`, the residential domains that `upos-*302*` redirects land on, and PCDN hosts wearing mirror-style names all count as slow. When Bilibili rotates to a new batch of PCDN domains, this usually keeps working without a change here.
-
-A few other things happen by default:
-
-- Candidate CDNs get probed for real, and the working order is cached per region. If you'd rather pin one host, Advanced settings has a fixed-server option.
-- When playback keeps stalling, it rotates to another route — no reload, no losing your position.
-- Live URLs (`/live-bvc/`) are never rewritten. Live and VOD run on separate CDN tiers, so a rewritten live URL simply won't play. Instead, obvious PCDN/MCDN entries are filtered out of the live room's server list, and at least one usable server always survives.
-- `fetch`, `XMLHttpRequest`, in-page play data, and quality switches all run through the same rewrite path.
-
 ## Panel and settings
 
-- The top of the panel shows status and how many connections were rewritten; below it is a live download-speed graph. When the CDN hides byte counts, it falls back to how many seconds are buffered ahead.
+- The top of the panel shows current status; below it is a live download-speed graph. When speed data isn't available, it falls back to how many seconds are buffered ahead.
 - Appearance follows the system theme. Once you pick the sun or moon in the header, that choice sticks.
 - Advanced settings has seven accents: Bilibili Blue, Teal, Emerald, Violet, Pink, Sunset, and Graphite.
-- **Still buffering? Boost harder** switches to the aggressive rewrite mode and reloads the page.
-- The bandwidth guard is off by default. Turning it on blocks Bilibili's P2P SDK and WebRTC upload entry points; reload the page afterwards.
+- **Still buffering? Boost harder** switches to a more aggressive mode and reloads the page.
+- The bandwidth guard is off by default. Turning it on limits the page's use of your upload bandwidth; reload the page afterwards.
 - In web fullscreen the ⚡ badge fades out. Move the pointer to the lower-right corner to bring it back.
 
 ## Releases
@@ -80,11 +55,11 @@ Full notes live in [Releases](https://github.com/realzza/bilibili-accelerator/re
 
 | Version | What changed |
 | --- | --- |
-| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | Light/dark panel and seven accent themes; header theme and language share one sliding control. Acceleration untouched |
-| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | Live streams no longer get rewritten; probes read real HTTP status; more hidden PCDN caught; stall recovery keeps rotating |
+| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | Light/dark panel and seven accent themes; header theme and language share one sliding control. Core behavior untouched |
+| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | Stability fixes for live playback, more accurate probing, and stall recovery that keeps retrying |
 | [v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2) | Speed measured over the time data is actually flowing, so a full buffer no longer reads as 0 Mbps |
 | [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | Live download-speed graph in the panel, with a buffer-health fallback |
-| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | Big one: behavioral slow-node detection, automatic server selection, stall recovery, EN/中 panel, optional bandwidth guard |
+| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | Big one: automatic connection tuning, stall recovery, EN/中 panel, optional bandwidth guard |
 | [v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3) | Lightning-only badge, auto-hide in web fullscreen, stops covering the fullscreen button |
 | [v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2) | Rebuilt the floating control and settings panel |
 | [v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1) | First installable userscript release |
@@ -93,12 +68,12 @@ Full notes live in [Releases](https://github.com/realzza/bilibili-accelerator/re
 
 Check for the ⚡ badge first. Tabs that were open during install or an update have to be reloaded.
 
-If it still stalls, open Advanced settings, hit **Copy report**, and file an [issue](https://github.com/realzza/bilibili-accelerator/issues) with the video URL, your region, and what you saw. The report contains hostnames and rewrite reasons only — no signed media URLs or query tokens.
+If it still stalls, open Advanced settings, hit **Copy report**, and file an [issue](https://github.com/realzza/bilibili-accelerator/issues) with the video URL, your region, and what you saw. The report contains only what's needed to diagnose the problem — no signed media addresses or query tokens.
 
 ## Limits
 
 - Browser player only. Apple TV and the native mobile apps are out of scope.
-- CDN health varies by region and ISP. This routes around known-bad nodes; it can't fix regional licensing, a broken source file, or your local network.
+- Network conditions vary by region and ISP. This helps in some situations, but it can't fix regional licensing, a broken source file, or your local network.
 - For why router-level proxying mostly doesn't help (and the certificate pinning problem on native apps), see [docs/router-proxy.md](docs/router-proxy.md).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [English](./README.en.md) · [Greasy Fork](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) · 当前版本 v0.3.0
 
-海外看 B 站，热门视频一般没什么问题，冷门视频经常被分到慢速海外镜像或者 MCDN/PCDN 节点上，然后就开始一秒一卡。
+海外看 B 站，热门视频一般没什么问题，冷门视频经常一会儿流畅、一会儿卡死。
 
-这个用户脚本做的事情很单一：在播放器真正去拉分片之前，把这类有问题的播放地址换成更稳的官方 CDN。正常的 CDN 地址默认一个都不碰。
+这个用户脚本用来改善这种情况：它在浏览器里观察播放过程，遇到明显不稳的连接时自动调整，并把实时下载速度显示在面板上。播放正常时不会介入。
 
 | ☀️ 浅色 | 🌙 深色 |
 | :---: | :---: |
@@ -40,38 +40,13 @@ npm run build
 
 然后打开 `chrome://extensions`，开启「开发者模式」，选择 `dist/extension`。
 
-## 它到底做了什么
-
-同一段视频，B 站通常会返回好几条带签名的播放地址。海外网络下，容易出问题的那几条长这样：
-
-```text
-upos-sz-mirrorcosov.bilivideo.com
-xy153x35x231x78xy.mcdn.bilivideo.cn:8082
-```
-
-脚本在请求发出去之前认出它们，换成这类地址：
-
-```text
-upos-sz-mirrorcos.bilivideo.com
-proxy-tf-all-ws.bilivideo.com
-```
-
-判断慢节点靠的不是一份手工维护的域名黑名单：奇怪端口、带 `os=mcdn`、`upos-*302*` 跳转落地的家宽域名，以及套着镜像名字的 PCDN，都按慢节点处理。所以 B 站换一批 PCDN 域名，这边一般不用跟着改。
-
-除此之外，默认还会做几件事：
-
-- 候选 CDN 会真的探一遍，按当前地区记住可用顺序。想钉死某台服务器的话，高级设置里可以固定。
-- 播放持续缓冲时自动换线，不刷新页面，也不用重新拖进度。
-- 直播地址（`/live-bvc/`）一律不改写——直播和点播是两套 CDN，改过去根本放不了。脚本只从直播线路列表里过滤掉明显的 PCDN/MCDN，并且保证至少留一条能用的。
-- `fetch`、`XMLHttpRequest`、页面里的播放数据、切清晰度，走的都是同一套改写逻辑。
-
 ## 面板与设置
 
-- 面板顶部是状态和已处理的连接数，下面是实时下载速度曲线。CDN 不给字节数的时候，会退回显示前方缓冲了多少秒。
+- 面板顶部是当前状态，下面是实时下载速度曲线。拿不到速度数据时，会退回显示前方缓冲了多少秒。
 - 明暗跟随系统。点顶部的日 / 月开关之后，就变成你手动指定的浅色或深色。
 - 高级设置里有 7 套主题色：哔哩蓝、青碧、翠绿、星紫、少女粉、落日橙、石墨灰。
-- 「还在卡？再加把劲」会切到更激进的改写策略，并刷新当前页面。
-- 带宽保护默认关闭，开启后会挡掉 B 站的 P2P SDK 和 WebRTC 上传入口，需要刷新页面生效。
+- 「还在卡？再加把劲」会切到更积极的模式，并刷新当前页面。
+- 带宽保护默认关闭，开启后会限制页面占用你的上传带宽，需要刷新页面生效。
 - 网页全屏时 ⚡ 会淡出，鼠标移到右下角就能重新唤出。
 
 ## 版本
@@ -80,11 +55,11 @@ proxy-tf-all-ws.bilivideo.com
 
 | 版本 | 主要变化 |
 | --- | --- |
-| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | 面板深浅色 + 7 套主题色；顶部主题 / 语言改成同一套滑动控件。加速逻辑没动 |
-| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | 直播不再被误改写；测速改为读真实 HTTP 状态；覆盖更多隐藏 PCDN；卡顿恢复会持续轮换 |
+| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | 面板深浅色 + 7 套主题色；顶部主题 / 语言改成同一套滑动控件。核心逻辑没动 |
+| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | 直播场景的稳定性修复；探测逻辑更准确；卡顿恢复会持续重试 |
 | [v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2) | 速度曲线按「数据真正在传输的时段」算，缓冲填满时不再假装掉到 0 |
-| [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | 面板加上实时下载速度曲线，拿不到字节数时退回显示缓冲时长 |
-| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | 大改版：行为特征识别慢节点、自动挑最快服务器、卡顿自动恢复、中英文面板、可选带宽保护 |
+| [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | 面板加上实时下载速度曲线，拿不到速度数据时退回显示缓冲时长 |
+| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | 大改版：自动优化播放连接、卡顿自动恢复、中英文面板、可选带宽保护 |
 | [v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3) | 悬浮图标改成纯 ⚡，网页全屏自动淡出，不再压住全屏按钮 |
 | [v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2) | 悬浮控件和设置面板重做 |
 | [v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1) | 首个可直接安装的用户脚本版本 |
@@ -93,12 +68,12 @@ proxy-tf-all-ws.bilivideo.com
 
 先看右下角有没有 ⚡。刚装完或刚更新的话，已经开着的 B 站页面必须刷新一次。
 
-还是卡的话，打开「高级设置」→「复制诊断报告」，然后带上视频地址、你所在的地区和具体现象发到 [Issues](https://github.com/realzza/bilibili-accelerator/issues)。报告里只有域名和改写原因，不含带签名参数的完整媒体 URL。
+还是卡的话，打开「高级设置」→「复制诊断报告」，然后带上视频地址、你所在的地区和具体现象发到 [Issues](https://github.com/realzza/bilibili-accelerator/issues)。报告只包含必要的诊断信息，不含带签名参数的完整媒体地址。
 
 ## 限制
 
 - 只管浏览器里的 B 站网页播放器，Apple TV 和手机 App 不在范围内。
-- CDN 状况本身就随地区和运营商变。脚本能绕开已知的慢线路，但解决不了版权地区限制、源文件本身有问题，或者你本地网络的锅。
+- 网络状况本身就随地区和运营商变。脚本能改善一部分情况，但解决不了版权地区限制、源文件本身有问题，或者你本地网络的锅。
 - 软路由方案为什么基本不管用（以及原生 App 的证书固定问题），见 [docs/router-proxy.md](docs/router-proxy.md)。
 
 ## 开发

--- a/dist/README.en.md
+++ b/dist/README.en.md
@@ -2,9 +2,9 @@
 
 [中文](./README.md) · [Greasy Fork](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) · v0.3.0
 
-Watching Bilibili from outside mainland China, popular videos are usually fine. Everything else tends to land on a slow overseas mirror or an MCDN/PCDN node, and then it buffers every few seconds.
+Watching Bilibili from outside mainland China, popular videos are usually fine. Everything else tends to stutter — smooth one moment, buffering the next.
 
-This userscript does one thing: before the player fetches a segment, it swaps those bad playback URLs for healthier official CDN hosts. Healthy CDN traffic is left alone.
+This userscript is meant to smooth that out. It watches playback in the browser, adjusts automatically when a connection is clearly unstable, and shows your live download speed in a panel. When playback is fine, it stays out of the way.
 
 | ☀️ Light | 🌙 Dark |
 | :---: | :---: |
@@ -40,38 +40,13 @@ npm run build
 
 Open `chrome://extensions`, turn on Developer mode, and load `dist/extension`.
 
-## What it actually does
-
-Bilibili returns several signed playback URLs for the same video. Overseas, the problematic ones look like this:
-
-```text
-upos-sz-mirrorcosov.bilivideo.com
-xy153x35x231x78xy.mcdn.bilivideo.cn:8082
-```
-
-The script spots them before the request goes out and rewrites them to something like:
-
-```text
-upos-sz-mirrorcos.bilivideo.com
-proxy-tf-all-ws.bilivideo.com
-```
-
-Detection isn't a hand-maintained domain blocklist. Odd ports, `os=mcdn`, the residential domains that `upos-*302*` redirects land on, and PCDN hosts wearing mirror-style names all count as slow. When Bilibili rotates to a new batch of PCDN domains, this usually keeps working without a change here.
-
-A few other things happen by default:
-
-- Candidate CDNs get probed for real, and the working order is cached per region. If you'd rather pin one host, Advanced settings has a fixed-server option.
-- When playback keeps stalling, it rotates to another route — no reload, no losing your position.
-- Live URLs (`/live-bvc/`) are never rewritten. Live and VOD run on separate CDN tiers, so a rewritten live URL simply won't play. Instead, obvious PCDN/MCDN entries are filtered out of the live room's server list, and at least one usable server always survives.
-- `fetch`, `XMLHttpRequest`, in-page play data, and quality switches all run through the same rewrite path.
-
 ## Panel and settings
 
-- The top of the panel shows status and how many connections were rewritten; below it is a live download-speed graph. When the CDN hides byte counts, it falls back to how many seconds are buffered ahead.
+- The top of the panel shows current status; below it is a live download-speed graph. When speed data isn't available, it falls back to how many seconds are buffered ahead.
 - Appearance follows the system theme. Once you pick the sun or moon in the header, that choice sticks.
 - Advanced settings has seven accents: Bilibili Blue, Teal, Emerald, Violet, Pink, Sunset, and Graphite.
-- **Still buffering? Boost harder** switches to the aggressive rewrite mode and reloads the page.
-- The bandwidth guard is off by default. Turning it on blocks Bilibili's P2P SDK and WebRTC upload entry points; reload the page afterwards.
+- **Still buffering? Boost harder** switches to a more aggressive mode and reloads the page.
+- The bandwidth guard is off by default. Turning it on limits the page's use of your upload bandwidth; reload the page afterwards.
 - In web fullscreen the ⚡ badge fades out. Move the pointer to the lower-right corner to bring it back.
 
 ## Releases
@@ -80,11 +55,11 @@ Full notes live in [Releases](https://github.com/realzza/bilibili-accelerator/re
 
 | Version | What changed |
 | --- | --- |
-| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | Light/dark panel and seven accent themes; header theme and language share one sliding control. Acceleration untouched |
-| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | Live streams no longer get rewritten; probes read real HTTP status; more hidden PCDN caught; stall recovery keeps rotating |
+| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | Light/dark panel and seven accent themes; header theme and language share one sliding control. Core behavior untouched |
+| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | Stability fixes for live playback, more accurate probing, and stall recovery that keeps retrying |
 | [v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2) | Speed measured over the time data is actually flowing, so a full buffer no longer reads as 0 Mbps |
 | [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | Live download-speed graph in the panel, with a buffer-health fallback |
-| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | Big one: behavioral slow-node detection, automatic server selection, stall recovery, EN/中 panel, optional bandwidth guard |
+| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | Big one: automatic connection tuning, stall recovery, EN/中 panel, optional bandwidth guard |
 | [v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3) | Lightning-only badge, auto-hide in web fullscreen, stops covering the fullscreen button |
 | [v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2) | Rebuilt the floating control and settings panel |
 | [v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1) | First installable userscript release |
@@ -93,12 +68,12 @@ Full notes live in [Releases](https://github.com/realzza/bilibili-accelerator/re
 
 Check for the ⚡ badge first. Tabs that were open during install or an update have to be reloaded.
 
-If it still stalls, open Advanced settings, hit **Copy report**, and file an [issue](https://github.com/realzza/bilibili-accelerator/issues) with the video URL, your region, and what you saw. The report contains hostnames and rewrite reasons only — no signed media URLs or query tokens.
+If it still stalls, open Advanced settings, hit **Copy report**, and file an [issue](https://github.com/realzza/bilibili-accelerator/issues) with the video URL, your region, and what you saw. The report contains only what's needed to diagnose the problem — no signed media addresses or query tokens.
 
 ## Limits
 
 - Browser player only. Apple TV and the native mobile apps are out of scope.
-- CDN health varies by region and ISP. This routes around known-bad nodes; it can't fix regional licensing, a broken source file, or your local network.
+- Network conditions vary by region and ISP. This helps in some situations, but it can't fix regional licensing, a broken source file, or your local network.
 - For why router-level proxying mostly doesn't help (and the certificate pinning problem on native apps), see [docs/router-proxy.md](docs/router-proxy.md).
 
 ## Development

--- a/dist/README.md
+++ b/dist/README.md
@@ -2,9 +2,9 @@
 
 [English](./README.en.md) · [Greasy Fork](https://greasyfork.org/en/scripts/582026-bilibili-accelerator) · 当前版本 v0.3.0
 
-海外看 B 站，热门视频一般没什么问题，冷门视频经常被分到慢速海外镜像或者 MCDN/PCDN 节点上，然后就开始一秒一卡。
+海外看 B 站，热门视频一般没什么问题，冷门视频经常一会儿流畅、一会儿卡死。
 
-这个用户脚本做的事情很单一：在播放器真正去拉分片之前，把这类有问题的播放地址换成更稳的官方 CDN。正常的 CDN 地址默认一个都不碰。
+这个用户脚本用来改善这种情况：它在浏览器里观察播放过程，遇到明显不稳的连接时自动调整，并把实时下载速度显示在面板上。播放正常时不会介入。
 
 | ☀️ 浅色 | 🌙 深色 |
 | :---: | :---: |
@@ -40,38 +40,13 @@ npm run build
 
 然后打开 `chrome://extensions`，开启「开发者模式」，选择 `dist/extension`。
 
-## 它到底做了什么
-
-同一段视频，B 站通常会返回好几条带签名的播放地址。海外网络下，容易出问题的那几条长这样：
-
-```text
-upos-sz-mirrorcosov.bilivideo.com
-xy153x35x231x78xy.mcdn.bilivideo.cn:8082
-```
-
-脚本在请求发出去之前认出它们，换成这类地址：
-
-```text
-upos-sz-mirrorcos.bilivideo.com
-proxy-tf-all-ws.bilivideo.com
-```
-
-判断慢节点靠的不是一份手工维护的域名黑名单：奇怪端口、带 `os=mcdn`、`upos-*302*` 跳转落地的家宽域名，以及套着镜像名字的 PCDN，都按慢节点处理。所以 B 站换一批 PCDN 域名，这边一般不用跟着改。
-
-除此之外，默认还会做几件事：
-
-- 候选 CDN 会真的探一遍，按当前地区记住可用顺序。想钉死某台服务器的话，高级设置里可以固定。
-- 播放持续缓冲时自动换线，不刷新页面，也不用重新拖进度。
-- 直播地址（`/live-bvc/`）一律不改写——直播和点播是两套 CDN，改过去根本放不了。脚本只从直播线路列表里过滤掉明显的 PCDN/MCDN，并且保证至少留一条能用的。
-- `fetch`、`XMLHttpRequest`、页面里的播放数据、切清晰度，走的都是同一套改写逻辑。
-
 ## 面板与设置
 
-- 面板顶部是状态和已处理的连接数，下面是实时下载速度曲线。CDN 不给字节数的时候，会退回显示前方缓冲了多少秒。
+- 面板顶部是当前状态，下面是实时下载速度曲线。拿不到速度数据时，会退回显示前方缓冲了多少秒。
 - 明暗跟随系统。点顶部的日 / 月开关之后，就变成你手动指定的浅色或深色。
 - 高级设置里有 7 套主题色：哔哩蓝、青碧、翠绿、星紫、少女粉、落日橙、石墨灰。
-- 「还在卡？再加把劲」会切到更激进的改写策略，并刷新当前页面。
-- 带宽保护默认关闭，开启后会挡掉 B 站的 P2P SDK 和 WebRTC 上传入口，需要刷新页面生效。
+- 「还在卡？再加把劲」会切到更积极的模式，并刷新当前页面。
+- 带宽保护默认关闭，开启后会限制页面占用你的上传带宽，需要刷新页面生效。
 - 网页全屏时 ⚡ 会淡出，鼠标移到右下角就能重新唤出。
 
 ## 版本
@@ -80,11 +55,11 @@ proxy-tf-all-ws.bilivideo.com
 
 | 版本 | 主要变化 |
 | --- | --- |
-| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | 面板深浅色 + 7 套主题色；顶部主题 / 语言改成同一套滑动控件。加速逻辑没动 |
-| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | 直播不再被误改写；测速改为读真实 HTTP 状态；覆盖更多隐藏 PCDN；卡顿恢复会持续轮换 |
+| [v0.3.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.3.0) | 面板深浅色 + 7 套主题色；顶部主题 / 语言改成同一套滑动控件。核心逻辑没动 |
+| [v0.2.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.3) | 直播场景的稳定性修复；探测逻辑更准确；卡顿恢复会持续重试 |
 | [v0.2.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.2) | 速度曲线按「数据真正在传输的时段」算，缓冲填满时不再假装掉到 0 |
-| [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | 面板加上实时下载速度曲线，拿不到字节数时退回显示缓冲时长 |
-| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | 大改版：行为特征识别慢节点、自动挑最快服务器、卡顿自动恢复、中英文面板、可选带宽保护 |
+| [v0.2.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.1) | 面板加上实时下载速度曲线，拿不到速度数据时退回显示缓冲时长 |
+| [v0.2.0](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.2.0) | 大改版：自动优化播放连接、卡顿自动恢复、中英文面板、可选带宽保护 |
 | [v0.1.3](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.3) | 悬浮图标改成纯 ⚡，网页全屏自动淡出，不再压住全屏按钮 |
 | [v0.1.2](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.2) | 悬浮控件和设置面板重做 |
 | [v0.1.1](https://github.com/realzza/bilibili-accelerator/releases/tag/v0.1.1) | 首个可直接安装的用户脚本版本 |
@@ -93,12 +68,12 @@ proxy-tf-all-ws.bilivideo.com
 
 先看右下角有没有 ⚡。刚装完或刚更新的话，已经开着的 B 站页面必须刷新一次。
 
-还是卡的话，打开「高级设置」→「复制诊断报告」，然后带上视频地址、你所在的地区和具体现象发到 [Issues](https://github.com/realzza/bilibili-accelerator/issues)。报告里只有域名和改写原因，不含带签名参数的完整媒体 URL。
+还是卡的话，打开「高级设置」→「复制诊断报告」，然后带上视频地址、你所在的地区和具体现象发到 [Issues](https://github.com/realzza/bilibili-accelerator/issues)。报告只包含必要的诊断信息，不含带签名参数的完整媒体地址。
 
 ## 限制
 
 - 只管浏览器里的 B 站网页播放器，Apple TV 和手机 App 不在范围内。
-- CDN 状况本身就随地区和运营商变。脚本能绕开已知的慢线路，但解决不了版权地区限制、源文件本身有问题，或者你本地网络的锅。
+- 网络状况本身就随地区和运营商变。脚本能改善一部分情况，但解决不了版权地区限制、源文件本身有问题，或者你本地网络的锅。
 - 软路由方案为什么基本不管用（以及原生 App 的证书固定问题），见 [docs/router-proxy.md](docs/router-proxy.md)。
 
 ## 开发

--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -3,8 +3,8 @@
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
 // @version      0.3.0
-// @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
-// @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
+// @description  Smoother Bilibili playback for overseas viewers.
+// @description:zh-CN 缓解海外用户看 B 站冷门视频时的卡顿。
 // @author       realzza
 // @license      MIT
 // @homepageURL  https://github.com/realzza/bilibili-accelerator

--- a/dist/extension/manifest.json
+++ b/dist/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
   "version": "0.3.0",
-  "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
+  "description": "Smoother Bilibili playback for overseas viewers.",
   "icons": {},
   "permissions": [
     "storage"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bilibili-accelerator",
   "version": "0.3.0",
   "private": true,
-  "description": "Safari-friendly Bilibili playback CDN accelerator.",
+  "description": "Smoother Bilibili playback for overseas viewers.",
   "scripts": {
     "build": "node scripts/build.mjs",
     "test": "node --test",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -22,8 +22,8 @@ const userscriptHeader = `// ==UserScript==
 // @name:zh-CN   Bilibili Accelerator - B站海外播放加速
 // @namespace    https://github.com/realzza/bilibili-accelerator
 // @version      ${pkg.version}
-// @description  Rewrite slow Bilibili playback CDN URLs for smoother overseas playback.
-// @description:zh-CN 自动改写 B 站慢 CDN 播放地址，缓解海外用户看冷门视频时的卡顿。
+// @description  Smoother Bilibili playback for overseas viewers.
+// @description:zh-CN 缓解海外用户看 B 站冷门视频时的卡顿。
 // @author       realzza
 // @license      MIT
 // @homepageURL  https://github.com/realzza/bilibili-accelerator

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Bilibili Accelerator",
   "version": "0.2.3",
-  "description": "Speeds up slow Bilibili playback by rewriting weak CDN/PCDN URLs before buffering.",
+  "description": "Smoother Bilibili playback for overseas viewers.",
   "icons": {},
   "permissions": [
     "storage"


### PR DESCRIPTION
Trims the README down to what the script is for, rather than how it decides which connections to change. Requested to reduce legal exposure in the public-facing description.

## What changed

**READMEs (both languages)** — removed the "它到底做了什么" / "What it actually does" section outright, including the example hostnames and the detection rules. Reworded elsewhere so the mechanism isn't described indirectly:

- Intro now says the script watches playback and adjusts unstable connections, without naming what it adjusts.
- Release table entries reworded (e.g. "覆盖更多隐藏 PCDN" → "探测逻辑更准确").
- Panel, troubleshooting, and limits sections scrubbed of the same terms.

Kept: install steps, light/dark previews, panel and settings, release history, troubleshooting, limits, development.

**Script and extension metadata** (second commit, separable) — the userscript `@description` is what Greasy Fork and Tampermonkey display on the listing page, and the manifest description is what the Chrome extension page shows. Both still read "Rewrite slow Bilibili playback CDN URLs" / "rewriting weak CDN/PCDN URLs", which would have left the original framing on the most visible surfaces. Aligned them with the README. Drop this commit if you'd rather leave the published metadata alone.

## Notes

Nothing in `src/` behavior changed — this is wording only, and `npm test` still passes (51 tests) with `dist/` rebuilt in sync. The `"cdn"` entry in `package.json` keywords was left alone; the package is `private` and never published.

I'm not able to assess the underlying legal question — this only changes what the docs say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)