### PR TITLE
Keep background playback out of stall recovery

### DIFF
--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -1503,7 +1503,12 @@
   }
 
   function handleStall() {
-    if (!watchedVideo || watchedVideo.paused || watchedVideo.ended) {
+    // Browsers throttle media/MSE work in background tabs, which can make the
+    // player emit a transient waiting/stalled event. Rotating CDN hosts in that
+    // state turns a harmless suspension into a real interruption, so defer the
+    // decision until the page is visible again.
+    stallTimer = null;
+    if (document.hidden || !watchedVideo || watchedVideo.paused || watchedVideo.ended) {
       return;
     }
     if (watchedVideo.readyState >= 3) {
@@ -1528,6 +1533,10 @@
   function onWaiting() {
     if (stallTimer) {
       clearTimeout(stallTimer);
+      stallTimer = null;
+    }
+    if (document.hidden) {
+      return;
     }
     stallTimer = setTimeout(handleStall, STALL_GRACE_MS);
   }
@@ -1540,6 +1549,26 @@
     if (state.status === "buffering") {
       state.status = "smooth";
       renderStatus();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      if (stallTimer) {
+        clearTimeout(stallTimer);
+        stallTimer = null;
+      }
+      return;
+    }
+
+    // A waiting event fired while hidden is deliberately ignored. Re-evaluate
+    // once foregrounded so a genuine, still-active stall keeps the normal grace
+    // period and recovery behavior.
+    if (watchedVideo && !watchedVideo.paused && !watchedVideo.ended &&
+        watchedVideo.readyState < 3) {
+      onWaiting();
+    } else {
+      onPlaying();
     }
   }
 
@@ -2009,6 +2038,7 @@
     document.addEventListener("mousemove", handlePointerMove, { passive: true });
     document.addEventListener("fullscreenchange", refreshImmersive);
     document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     ensurePlayerObserver();
     setInterval(ensurePlayerObserver, 1500);
   }

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -1486,7 +1486,12 @@
   }
 
   function handleStall() {
-    if (!watchedVideo || watchedVideo.paused || watchedVideo.ended) {
+    // Browsers throttle media/MSE work in background tabs, which can make the
+    // player emit a transient waiting/stalled event. Rotating CDN hosts in that
+    // state turns a harmless suspension into a real interruption, so defer the
+    // decision until the page is visible again.
+    stallTimer = null;
+    if (document.hidden || !watchedVideo || watchedVideo.paused || watchedVideo.ended) {
       return;
     }
     if (watchedVideo.readyState >= 3) {
@@ -1511,6 +1516,10 @@
   function onWaiting() {
     if (stallTimer) {
       clearTimeout(stallTimer);
+      stallTimer = null;
+    }
+    if (document.hidden) {
+      return;
     }
     stallTimer = setTimeout(handleStall, STALL_GRACE_MS);
   }
@@ -1523,6 +1532,26 @@
     if (state.status === "buffering") {
       state.status = "smooth";
       renderStatus();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      if (stallTimer) {
+        clearTimeout(stallTimer);
+        stallTimer = null;
+      }
+      return;
+    }
+
+    // A waiting event fired while hidden is deliberately ignored. Re-evaluate
+    // once foregrounded so a genuine, still-active stall keeps the normal grace
+    // period and recovery behavior.
+    if (watchedVideo && !watchedVideo.paused && !watchedVideo.ended &&
+        watchedVideo.readyState < 3) {
+      onWaiting();
+    } else {
+      onPlaying();
     }
   }
 
@@ -1992,6 +2021,7 @@
     document.addEventListener("mousemove", handlePointerMove, { passive: true });
     document.addEventListener("fullscreenchange", refreshImmersive);
     document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     ensurePlayerObserver();
     setInterval(ensurePlayerObserver, 1500);
   }

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -859,7 +859,12 @@
   }
 
   function handleStall() {
-    if (!watchedVideo || watchedVideo.paused || watchedVideo.ended) {
+    // Browsers throttle media/MSE work in background tabs, which can make the
+    // player emit a transient waiting/stalled event. Rotating CDN hosts in that
+    // state turns a harmless suspension into a real interruption, so defer the
+    // decision until the page is visible again.
+    stallTimer = null;
+    if (document.hidden || !watchedVideo || watchedVideo.paused || watchedVideo.ended) {
       return;
     }
     if (watchedVideo.readyState >= 3) {
@@ -884,6 +889,10 @@
   function onWaiting() {
     if (stallTimer) {
       clearTimeout(stallTimer);
+      stallTimer = null;
+    }
+    if (document.hidden) {
+      return;
     }
     stallTimer = setTimeout(handleStall, STALL_GRACE_MS);
   }
@@ -896,6 +905,26 @@
     if (state.status === "buffering") {
       state.status = "smooth";
       renderStatus();
+    }
+  }
+
+  function onVisibilityChange() {
+    if (document.hidden) {
+      if (stallTimer) {
+        clearTimeout(stallTimer);
+        stallTimer = null;
+      }
+      return;
+    }
+
+    // A waiting event fired while hidden is deliberately ignored. Re-evaluate
+    // once foregrounded so a genuine, still-active stall keeps the normal grace
+    // period and recovery behavior.
+    if (watchedVideo && !watchedVideo.paused && !watchedVideo.ended &&
+        watchedVideo.readyState < 3) {
+      onWaiting();
+    } else {
+      onPlaying();
     }
   }
 
@@ -1365,6 +1394,7 @@
     document.addEventListener("mousemove", handlePointerMove, { passive: true });
     document.addEventListener("fullscreenchange", refreshImmersive);
     document.addEventListener("webkitfullscreenchange", refreshImmersive);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     ensurePlayerObserver();
     setInterval(ensurePlayerObserver, 1500);
   }

--- a/test/v2-page.test.js
+++ b/test/v2-page.test.js
@@ -42,6 +42,91 @@ function loadPage() {
   return sandbox;
 }
 
+function loadPageWithVideo() {
+  const core = fs.readFileSync(path.join(__dirname, "../src/core/rewrite.js"), "utf8");
+  const page = fs.readFileSync(path.join(__dirname, "../src/page/bili-accelerator.page.js"), "utf8");
+  const documentListeners = new Map();
+  const videoListeners = new Map();
+  const timers = new Map();
+  let nextTimer = 1;
+
+  const video = {
+    paused: false,
+    ended: false,
+    readyState: 1,
+    currentTime: 10,
+    currentSrc: "blob:https://www.bilibili.com/media-source",
+    addEventListener(type, listener) {
+      videoListeners.set(type, listener);
+    },
+    dispatch(type) {
+      const listener = videoListeners.get(type);
+      if (listener) listener();
+    }
+  };
+
+  const document = {
+    readyState: "complete",
+    documentElement: null,
+    head: null,
+    hidden: false,
+    addEventListener(type, listener) {
+      documentListeners.set(type, listener);
+    },
+    dispatch(type) {
+      const listener = documentListeners.get(type);
+      if (listener) listener();
+    },
+    getElementById: () => null,
+    querySelector(selector) {
+      return selector === "video" ? video : null;
+    },
+    createElement: () => ({})
+  };
+
+  const sandbox = {
+    JSON: { parse: JSON.parse, stringify: JSON.stringify },
+    URL, Date, WeakSet, Headers, Response, Request, Promise, Math, Intl,
+    performance: { now: () => 1 },
+    XMLHttpRequest: class FakeXHR {
+      open() {}
+      send() {}
+      addEventListener() {}
+    },
+    navigator: { language: "en-US", clipboard: { writeText() {} } },
+    console: { info() {}, warn() {}, error() {} },
+    localStorage: { getItem: () => null, setItem() {} },
+    location: { href: "https://www.bilibili.com/video/x", reload() {} },
+    document,
+    setTimeout(callback, delay) {
+      const id = nextTimer++;
+      timers.set(id, { callback, delay, interval: false });
+      return id;
+    },
+    clearTimeout(id) { timers.delete(id); },
+    setInterval(callback, delay) {
+      const id = nextTimer++;
+      timers.set(id, { callback, delay, interval: true });
+      return id;
+    },
+    clearInterval(id) { timers.delete(id); }
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.window = sandbox;
+  sandbox.addEventListener = () => {};
+  sandbox.runTimeouts = function runTimeouts(delay) {
+    const due = Array.from(timers.entries()).filter(([, timer]) =>
+      !timer.interval && (delay == null || timer.delay === delay));
+    due.forEach(([id, timer]) => {
+      timers.delete(id);
+      timer.callback();
+    });
+  };
+
+  vm.runInNewContext(`${core}\n${page}`, sandbox);
+  return { sandbox, document, video };
+}
+
 test("XHR open() rewrites a renamed PCDN segment URL (mountaintoys)", () => {
   const sandbox = loadPage();
   const xhr = new sandbox.XMLHttpRequest();
@@ -49,6 +134,24 @@ test("XHR open() rewrites a renamed PCDN segment URL (mountaintoys)", () => {
   xhr.open("GET", bad);
   assert.equal(new URL(xhr._url).hostname, "upos-sz-mirrorcos.bilivideo.com");
   assert.equal(new URL(xhr._url).port, "");
+});
+
+test("stall recovery waits until a hidden video tab is visible again", () => {
+  const { sandbox, document, video } = loadPageWithVideo();
+
+  video.dispatch("waiting");
+  document.hidden = true;
+  document.dispatch("visibilitychange");
+  video.dispatch("waiting");
+  sandbox.runTimeouts(2500);
+  assert.equal(sandbox.BiliAccelerator.getStats().recoveries, 0,
+    "does not rotate CDN hosts after the tab becomes hidden");
+
+  document.hidden = false;
+  document.dispatch("visibilitychange");
+  sandbox.runTimeouts(2500);
+  assert.equal(sandbox.BiliAccelerator.getStats().recoveries, 1,
+    "rechecks an unresolved stall after the tab becomes visible");
 });
 
 test("playinfo rewrite also adds DASH backupUrl fan-out in auto mode", () => {


### PR DESCRIPTION
## What changed

- cancel pending stall recovery when the Bilibili tab becomes hidden
- ignore background-only `waiting`/`stalled` events
- re-evaluate unresolved stalls after the tab becomes visible
- rebuild the userscript and extension artifacts

## Why

Browsers can transiently throttle media and MSE work in background tabs. The accelerator treated those signals as real network stalls after its 2.5-second grace period and began rotating CDN routing every five seconds. That could turn a harmless background suspension into interrupted playback.

Foreground stall recovery is unchanged: if playback is still stalled after returning to the tab, the normal grace period and recovery path run.

## Validation

- `npm run build`
- `npm test` (52 passing)
- `git diff --check`
- regression test covers hiding a tab with a pending stall, ignoring hidden stall events, and resuming recovery after visibility returns
