### PR TITLE
feat: 增加直播 HLS 预加载与稳定性控制

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 node_modules/
 .DS_Store
+
+/browser-tests/
+/dist/bilibili-accelerator-extension.zip
+/docs/analysis/upstream-video-acceleration.md
+/package-lock.json
+/test/live-prefetch-runtime.test.js
+/test/live-stability.test.js
+/test/page-live-integration.test.js

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,12 +1,15 @@
 import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = path.resolve(new URL("..", import.meta.url).pathname);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const dist = path.join(root, "dist");
 const extensionDist = path.join(dist, "extension");
 
 const pkg = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
 const core = await readFile(path.join(root, "src/core/rewrite.js"), "utf8");
+const liveCore = await readFile(path.join(root, "src/core/live-stability.js"), "utf8");
+const liveRuntime = await readFile(path.join(root, "src/page/live-stability.runtime.js"), "utf8");
 const page = await readFile(path.join(root, "src/page/bili-accelerator.page.js"), "utf8");
 const content = await readFile(path.join(root, "src/extension/content.js"), "utf8");
 const manifest = JSON.parse(await readFile(path.join(root, "src/extension/manifest.json"), "utf8"));
@@ -38,8 +41,9 @@ const userscriptHeader = `// ==UserScript==
 await rm(dist, { recursive: true, force: true });
 await mkdir(extensionDist, { recursive: true });
 
-await writeFile(path.join(dist, "bilibili-accelerator.user.js"), `${userscriptHeader}\n${core}\n${page}\n`);
-await writeFile(path.join(extensionDist, "bili-accelerator.page.js"), `${core}\n${page}\n`);
+const pageBundle = `${core}\n${liveCore}\n${liveRuntime}\n${page}\n`;
+await writeFile(path.join(dist, "bilibili-accelerator.user.js"), `${userscriptHeader}\n${pageBundle}`);
+await writeFile(path.join(extensionDist, "bili-accelerator.page.js"), pageBundle);
 await writeFile(path.join(extensionDist, "content.js"), content);
 await writeFile(path.join(extensionDist, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
 await writeFile(path.join(extensionDist, "popup.html"), popupHtml);

--- a/src/core/live-stability.js
+++ b/src/core/live-stability.js
@@ -1,0 +1,519 @@
+(function initBiliAcceleratorLiveStability(root, factory) {
+  const core = typeof module === "object" && module.exports
+    ? require("./rewrite")
+    : root.BiliAcceleratorCore;
+  const liveStability = factory(core);
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = liveStability;
+  }
+
+  root.BiliAcceleratorLiveStability = liveStability;
+})(typeof globalThis !== "undefined" ? globalThis : window, function createLiveStability(core) {
+  "use strict";
+
+  const FORMAT_ORDER = Object.freeze({ fmp4: 0, flv: 1, ts: 2 });
+  const UNSUPPORTED_TAGS = Object.freeze({
+    "#EXT-X-BYTERANGE": "byterange",
+    "#EXT-X-PART": "part",
+    "#EXT-X-PRELOAD-HINT": "preload-hint",
+    "#EXT-X-GAP": "gap",
+    "#EXT-X-SKIP": "skip"
+  });
+
+  function normalizePolicy(rawConfig) {
+    const config = core.normalizeConfig(rawConfig);
+    return {
+      active: rawConfig && typeof rawConfig.active === "boolean"
+        ? rawConfig.active
+        : config.enabled && config.mode !== "off",
+      liveProtocolPreference: config.liveProtocolPreference,
+      livePrefetchEnabled: config.livePrefetchEnabled,
+      livePrefetchTargetSeconds: config.livePrefetchTargetSeconds,
+      livePrefetchMaxSegments: config.livePrefetchMaxSegments,
+      livePrefetchConcurrency: config.livePrefetchConcurrency,
+      livePrefetchCacheMiB: config.livePrefetchCacheMiB
+    };
+  }
+
+  function getPlayurl(payload) {
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+    if (payload.data && payload.data.playurl_info && payload.data.playurl_info.playurl) {
+      return payload.data.playurl_info.playurl;
+    }
+    if (payload.playurl_info && payload.playurl_info.playurl) {
+      return payload.playurl_info.playurl;
+    }
+    return Array.isArray(payload.stream) ? payload : null;
+  }
+
+  function addExtra(url, extra) {
+    if (typeof extra !== "string" || !extra) {
+      return url.toString();
+    }
+    const query = extra.replace(/^[?&]/, "");
+    if (!query) {
+      return url.toString();
+    }
+    const resolved = url.toString();
+    const hashIndex = resolved.indexOf("#");
+    const beforeHash = hashIndex === -1 ? resolved : resolved.slice(0, hashIndex);
+    const hash = hashIndex === -1 ? "" : resolved.slice(hashIndex);
+    const tail = beforeHash.charAt(beforeHash.length - 1);
+    const separator = beforeHash.indexOf("?") === -1 ? "?" :
+      (tail === "?" || tail === "&" ? "" : "&");
+    return beforeHash + separator + query + hash;
+  }
+
+  function completeUrl(host, baseUrl, extra) {
+    if (typeof baseUrl !== "string" || !baseUrl) {
+      return null;
+    }
+    try {
+      const base = typeof host === "string" && host
+        ? new URL(baseUrl, host.indexOf("://") === -1 ? "https://" + host : host)
+        : new URL(baseUrl);
+      return addExtra(base, extra);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function isPlaylistUrl(value) {
+    try {
+      return new URL(value).pathname.toLowerCase().endsWith(".m3u8");
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function hlsPlan(playurl) {
+    const plan = [];
+    const streams = Array.isArray(playurl.stream) ? playurl.stream : [];
+    streams.forEach(function eachStream(stream, streamIndex) {
+      const formats = stream && Array.isArray(stream.format) ? stream.format : [];
+      formats.forEach(function eachFormat(format, formatIndex) {
+        const codecs = format && Array.isArray(format.codec) ? format.codec : [];
+        codecs.forEach(function eachCodec(codec, codecIndex) {
+          const urls = codec && Array.isArray(codec.url_info) ? codec.url_info : [];
+          if (urls.length === 0) {
+            const complete = completeUrl("", codec && codec.base_url, "");
+            if (complete && isPlaylistUrl(complete)) {
+              plan.push({
+                url: complete,
+                identity: { streamIndex, formatIndex, codecIndex, urlInfoIndex: -1 }
+              });
+            }
+            return;
+          }
+          urls.forEach(function eachUrlInfo(urlInfo, urlInfoIndex) {
+            const complete = completeUrl(urlInfo && urlInfo.host, codec && codec.base_url, urlInfo && urlInfo.extra);
+            if (complete && isPlaylistUrl(complete)) {
+              plan.push({
+                url: complete,
+                identity: { streamIndex, formatIndex, codecIndex, urlInfoIndex }
+              });
+            }
+          });
+        });
+      });
+    });
+    return plan;
+  }
+
+  // This only reorders the format array. Codec entries and their host candidates
+  // are deliberately retained verbatim so player failover remains intact.
+  function transformPlayInfo(payload, rawConfig) {
+    const policy = normalizePolicy(rawConfig);
+    const playurl = getPlayurl(payload);
+    const rewrites = [];
+    let changed = false;
+    if (!policy.active || !playurl) {
+      return { changed, rewrites, plan: [], matched: Boolean(playurl) };
+    }
+
+    if (policy.liveProtocolPreference === "stable") {
+      const streams = Array.isArray(playurl.stream) ? playurl.stream : [];
+      streams.forEach(function eachStream(stream, streamIndex) {
+        if (!stream || !Array.isArray(stream.format)) {
+          return;
+        }
+        const original = stream.format.slice();
+        const ordered = original.map(function withIndex(format, index) {
+          const formatName = String(format && format.format_name || "").toLowerCase();
+          return { format, index, rank: Object.prototype.hasOwnProperty.call(FORMAT_ORDER, formatName) ? FORMAT_ORDER[formatName] : 3 };
+        }).sort(function stableFormatOrder(a, b) {
+          return a.rank - b.rank || a.index - b.index;
+        });
+        if (ordered.some(function moved(item, index) { return item.index !== index; })) {
+          stream.format.length = 0;
+          ordered.forEach(function insert(item, index) {
+            stream.format.push(item.format);
+            rewrites.push({
+              changed: true,
+              reason: "live-format-order",
+              streamIndex,
+              originalIndex: item.index,
+              formatIndex: index,
+              formatName: String(item.format && item.format.format_name || "")
+            });
+          });
+          changed = true;
+        }
+      });
+      const orderedStreams = streams.map(function withStreamIndex(stream, index) {
+        const formats = stream && Array.isArray(stream.format) ? stream.format : [];
+        let rank = 3;
+        formats.forEach(function findBestFormat(format) {
+          const name = String(format && format.format_name || "").toLowerCase();
+          if (Object.prototype.hasOwnProperty.call(FORMAT_ORDER, name)) {
+            rank = Math.min(rank, FORMAT_ORDER[name]);
+          }
+        });
+        return { stream, index, rank };
+      }).sort(function stableStreamOrder(a, b) {
+        return a.rank - b.rank || a.index - b.index;
+      });
+      if (orderedStreams.some(function moved(item, index) { return item.index !== index; })) {
+        playurl.stream.length = 0;
+        orderedStreams.forEach(function insertStream(item, streamIndex) {
+          playurl.stream.push(item.stream);
+          rewrites.push({
+            changed: true,
+            reason: "live-stream-order",
+            originalIndex: item.index,
+            streamIndex
+          });
+        });
+        changed = true;
+      }
+    }
+
+    return { changed, rewrites, plan: hlsPlan(playurl), matched: true };
+  }
+
+  function resolveUrl(value, baseUrl) {
+    try {
+      return new URL(value, baseUrl).toString();
+    } catch (_) {
+      return value;
+    }
+  }
+
+  function resolveSegmentUrl(value, baseUrl) {
+    const resolved = resolveUrl(value, baseUrl);
+    const reference = String(value || "");
+    const withoutHash = reference.split("#")[0];
+    if (!resolved || withoutHash.indexOf("?") !== -1 ||
+        /^[a-z][a-z0-9+.-]*:|^\/\//i.test(reference)) {
+      return resolved;
+    }
+    try {
+      const base = new URL(baseUrl);
+      if (!base.search) {
+        return resolved;
+      }
+      const segment = new URL(resolved);
+      segment.search = base.search;
+      return segment.toString();
+    } catch (_) {
+      return resolved;
+    }
+  }
+
+  function attributeUri(line) {
+    const match = /(?:^|[:,])URI=(?:"([^"]*)"|([^,]*))/i.exec(line);
+    return match ? (match[1] === undefined ? match[2] : match[1]) : null;
+  }
+
+  function parsePlaylist(baseUrl, text) {
+    const lines = String(text || "").replace(/^\uFEFF/, "").split(/\r?\n/);
+    const variants = [];
+    const media = [];
+    const maps = [];
+    const segments = [];
+    const unsupported = [];
+    let sequence = 0;
+    let pendingDuration = null;
+    let expectsVariant = false;
+    let discontinuityBefore = false;
+    let currentMapUrl = null;
+    let master = false;
+
+    function markUnsupported(value) {
+      if (unsupported.indexOf(value) === -1) {
+        unsupported.push(value);
+      }
+    }
+
+    lines.forEach(function parseLine(rawLine) {
+      const line = rawLine.trim();
+      if (!line) {
+        return;
+      }
+      if (line.indexOf("#EXT-X-STREAM-INF:") === 0) {
+        master = true;
+        expectsVariant = true;
+        return;
+      }
+      if (line.indexOf("#EXT-X-I-FRAME-STREAM-INF:") === 0) {
+        master = true;
+        const iframeUri = attributeUri(line);
+        if (iframeUri) {
+          variants.push(resolveUrl(iframeUri, baseUrl));
+        }
+        return;
+      }
+      if (line.indexOf("#EXT-X-MEDIA:") === 0) {
+        master = true;
+        const mediaUri = attributeUri(line);
+        if (mediaUri) {
+          media.push(resolveUrl(mediaUri, baseUrl));
+        }
+        return;
+      }
+      if (line.indexOf("#EXT-X-MEDIA-SEQUENCE:") === 0) {
+        const value = Number(line.slice("#EXT-X-MEDIA-SEQUENCE:".length));
+        sequence = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+        return;
+      }
+      if (line.indexOf("#EXTINF:") === 0) {
+        const value = Number(line.slice("#EXTINF:".length).split(",")[0]);
+        pendingDuration = Number.isFinite(value) && value >= 0 ? value : 0;
+        return;
+      }
+      if (line === "#EXT-X-DISCONTINUITY") {
+        discontinuityBefore = true;
+        return;
+      }
+      if (line.indexOf("#EXT-X-KEY:") === 0 && !/METHOD=NONE(?:,|$)/i.test(line)) {
+        markUnsupported("encryption");
+        return;
+      }
+      if (line.indexOf("#EXT-X-MAP:") === 0) {
+        const mapUri = attributeUri(line);
+        if (mapUri) {
+          currentMapUrl = resolveUrl(mapUri, baseUrl);
+          maps.push(currentMapUrl);
+        }
+        return;
+      }
+      Object.keys(UNSUPPORTED_TAGS).some(function checkTag(tag) {
+        if (line.indexOf(tag) === 0) {
+          markUnsupported(UNSUPPORTED_TAGS[tag]);
+          return true;
+        }
+        return false;
+      });
+      if (line.charAt(0) === "#") {
+        return;
+      }
+      if (expectsVariant) {
+        variants.push(resolveUrl(line, baseUrl));
+        expectsVariant = false;
+        return;
+      }
+      segments.push({
+        url: resolveSegmentUrl(line, baseUrl),
+        duration: pendingDuration === null ? 0 : pendingDuration,
+        sequence,
+        discontinuityBefore,
+        mapUrl: currentMapUrl
+      });
+      sequence += 1;
+      pendingDuration = null;
+      discontinuityBefore = false;
+    });
+
+    return {
+      type: master ? "master" : "media",
+      mediaSequence: segments.length ? segments[0].sequence : sequence,
+      variants,
+      media,
+      maps,
+      segments,
+      unsupported
+    };
+  }
+
+  function cursorSequence(cursor) {
+    if (typeof cursor === "number" && Number.isFinite(cursor)) {
+      return cursor;
+    }
+    if (cursor && typeof cursor.sequence === "number" && Number.isFinite(cursor.sequence)) {
+      return cursor.sequence;
+    }
+    return null;
+  }
+
+  function collectionHas(collection, value) {
+    if (!collection) {
+      return false;
+    }
+    if (typeof collection.has === "function") {
+      return collection.has(value);
+    }
+    return Array.isArray(collection) && collection.indexOf(value) !== -1;
+  }
+
+  function planPrefetch(playlist, cursor, bufferedSeconds, cacheState, rawPolicy) {
+    const policy = normalizePolicy(rawPolicy);
+    const observed = cursorSequence(cursor);
+    if (!policy.livePrefetchEnabled || observed === null || !playlist ||
+        playlist.type !== "media" || (playlist.unsupported && playlist.unsupported.length)) {
+      return [];
+    }
+    const state = cacheState || {};
+    const cacheBytes = (Number(state.cachedBytes) || 0) + (Number(state.inFlightBytes) || 0);
+    if (cacheBytes >= policy.livePrefetchCacheMiB * 1024 * 1024) {
+      return [];
+    }
+    const buffered = Math.max(0, Number(bufferedSeconds) || 0);
+    const reserved = Math.max(0, Number(state.reservedDuration) || 0);
+    let remaining = policy.livePrefetchTargetSeconds - buffered - reserved;
+    if (!(remaining > 0)) {
+      return [];
+    }
+    const planned = [];
+    const segments = Array.isArray(playlist.segments) ? playlist.segments : [];
+    let cursorMapUrl = null;
+    let cursorMapKnown = Boolean(cursor && typeof cursor === "object" &&
+      Object.prototype.hasOwnProperty.call(cursor, "mapUrl"));
+    if (cursorMapKnown) {
+      cursorMapUrl = cursor.mapUrl || null;
+    } else {
+      for (let index = 0; index < segments.length; index += 1) {
+        if (segments[index] && segments[index].sequence === observed) {
+          cursorMapUrl = segments[index].mapUrl || null;
+          cursorMapKnown = true;
+          break;
+        }
+      }
+    }
+    for (let i = 0; i < segments.length && planned.length < policy.livePrefetchMaxSegments; i += 1) {
+      const segment = segments[i];
+      if (!segment || !(segment.sequence > observed)) {
+        continue;
+      }
+      if (segment.discontinuityBefore) {
+        break;
+      }
+      const segmentMapUrl = segment.mapUrl || null;
+      if (cursorMapKnown && segmentMapUrl !== cursorMapUrl) {
+        break;
+      }
+      if (!cursorMapKnown) {
+        cursorMapUrl = segmentMapUrl;
+        cursorMapKnown = true;
+      }
+      if (collectionHas(state.reservedUrls, segment.url)) {
+        continue;
+      }
+      const duration = Number(segment.duration) || 0;
+      planned.push(segment);
+      remaining -= duration;
+      if (!(remaining > 0)) {
+        break;
+      }
+    }
+    return planned;
+  }
+
+  function headersToObject(headers) {
+    const values = {};
+    if (!headers) {
+      return values;
+    }
+    function copy(value, key) {
+      const normalizedKey = String(key).trim().toLowerCase();
+      const normalizedValue = String(value).trim();
+      if (!normalizedKey) {
+        return;
+      }
+      values[normalizedKey] = Object.prototype.hasOwnProperty.call(values, normalizedKey)
+        ? values[normalizedKey] + ", " + normalizedValue
+        : normalizedValue;
+    }
+    if (Array.isArray(headers)) {
+      headers.forEach(function copyTuple(tuple) {
+        if (Array.isArray(tuple) && tuple.length >= 2) {
+          copy(tuple[1], tuple[0]);
+        }
+      });
+    } else if (typeof headers.forEach === "function") {
+      headers.forEach(copy);
+    } else {
+      Object.keys(headers).forEach(function copyKey(key) { copy(headers[key], key); });
+    }
+    return values;
+  }
+
+  function classifyRequest(input, init) {
+    const requestLike = input && typeof input === "object" && typeof input.url === "string" && input.headers;
+    const source = requestLike ? input : null;
+    const rawUrl = source ? source.url : input instanceof URL ? input.toString() : String(input || "");
+    let url = rawUrl;
+    try { url = new URL(rawUrl).toString(); } catch (_) { /* keep the caller value for observability */ }
+    const overrides = init && typeof init === "object" ? init : {};
+    const hasOwn = Object.prototype.hasOwnProperty;
+    function overridesWithValue(key) {
+      return hasOwn.call(overrides, key) && overrides[key] !== undefined;
+    }
+    const headers = overridesWithValue("headers") ? headersToObject(overrides.headers) : headersToObject(source && source.headers);
+    const method = String(overridesWithValue("method") ? overrides.method : source && source.method || "GET").toUpperCase();
+    let inheritedBody = null;
+    if (source) {
+      try { inheritedBody = source.body === null || source.body === undefined ? null : true; } catch (_) { inheritedBody = true; }
+    }
+    const body = overridesWithValue("body") ? overrides.body : inheritedBody;
+    const credentials = overridesWithValue("credentials") ? overrides.credentials : source && source.credentials || "same-origin";
+    const mode = overridesWithValue("mode") ? overrides.mode : source && source.mode || "cors";
+    const cache = overridesWithValue("cache") ? overrides.cache : source && source.cache || "default";
+    const redirect = overridesWithValue("redirect") ? overrides.redirect : source && source.redirect || "follow";
+    const integrity = String(overridesWithValue("integrity") ? overrides.integrity : source && source.integrity || "");
+    const referrer = String(overridesWithValue("referrer")
+      ? overrides.referrer
+      : source && typeof source.referrer === "string" ? source.referrer : "about:client");
+    const referrerPolicy = String(overridesWithValue("referrerPolicy") ? overrides.referrerPolicy : source && source.referrerPolicy || "");
+    const keepalive = Boolean(overridesWithValue("keepalive") ? overrides.keepalive : source && source.keepalive || false);
+    let pathname = "";
+    try { pathname = new URL(url).pathname.toLowerCase(); } catch (_) { pathname = String(url).split(/[?#]/)[0].toLowerCase(); }
+    const kind = /\.m3u8$/.test(pathname) ? "playlist" : /\.flv$/.test(pathname) ? "flv" :
+      /\.(?:m4s|ts|mp4|m4a|aac)$/.test(pathname) ? "segment" : "other";
+    const range = headers.range || null;
+    const auth = Boolean(headers.authorization);
+    const standardHeaders = { accept: true, "accept-language": true, "content-language": true, "content-type": true, range: true, authorization: true };
+    const customHeader = Object.keys(headers).some(function isCustom(key) { return !standardHeaders[key]; });
+    const fingerprintHeaders = Object.keys(headers).sort().map(function fingerprintHeader(key) {
+      const sensitive = key === "authorization" || key === "proxy-authorization" || key === "cookie";
+      return [key, sensitive ? "<present>" : headers[key]];
+    });
+    return {
+      url,
+      kind,
+      method,
+      body,
+      headers,
+      range,
+      auth,
+      customHeader,
+      credentials,
+      mode,
+      cache,
+      redirect,
+      integrity,
+      referrer,
+      referrerPolicy,
+      keepalive,
+      fingerprint: JSON.stringify({
+        url, kind, method, headers: fingerprintHeaders, range, auth, customHeader,
+        credentials, mode, cache, redirect, integrity, referrer, referrerPolicy,
+        keepalive, hasBody: body !== null && body !== undefined
+      })
+    };
+  }
+
+  return { normalizePolicy, transformPlayInfo, parsePlaylist, planPrefetch, classifyRequest };
+});

--- a/src/core/rewrite.js
+++ b/src/core/rewrite.js
@@ -9,7 +9,7 @@
 })(typeof globalThis !== "undefined" ? globalThis : window, function createCore() {
   "use strict";
 
-  const SCHEMA_VERSION = 3;
+  const SCHEMA_VERSION = 4;
 
   // Healthy UPOS mirrors we are willing to rewrite toward. The default target
   // is DEFAULT_CONFIG.pcdnHost and the auto-selection pool is CANDIDATE_POOL;
@@ -41,6 +41,20 @@
     "graphite"
   ]);
   const THEME_MODES = Object.freeze(["system", "light", "dark"]);
+
+  // Live controls deliberately remain flat in persisted configuration. Keeping
+  // their metadata here gives the UI and the runtime one validation authority.
+  const LIVE_SETTINGS = Object.freeze({
+    liveProtocolPreference: Object.freeze({
+      values: Object.freeze(["original", "stable"]),
+      default: "original"
+    }),
+    livePrefetchEnabled: Object.freeze({ default: false }),
+    livePrefetchTargetSeconds: Object.freeze({ default: 6, min: 2, max: 12, step: 1 }),
+    livePrefetchMaxSegments: Object.freeze({ default: 2, min: 1, max: 4, step: 1 }),
+    livePrefetchConcurrency: Object.freeze({ default: 1, min: 1, max: 2, step: 1 }),
+    livePrefetchCacheMiB: Object.freeze({ default: 24, min: 8, max: 64, step: 1 })
+  });
 
   // Candidates that are safe to auto-probe and rank as rewrite targets. Akamai
   // is excluded: it rejects a upos-signed path with 403, so it can never win a
@@ -87,6 +101,12 @@
     portHeuristic: true,                           // non-default port ⇒ PCDN
     stallRecovery: true,                           // live failover on buffering
     p2pGuard: false,                               // opt-in WebRTC/PCDN neutralizer
+    liveProtocolPreference: LIVE_SETTINGS.liveProtocolPreference.default,
+    livePrefetchEnabled: LIVE_SETTINGS.livePrefetchEnabled.default,
+    livePrefetchTargetSeconds: LIVE_SETTINGS.livePrefetchTargetSeconds.default,
+    livePrefetchMaxSegments: LIVE_SETTINGS.livePrefetchMaxSegments.default,
+    livePrefetchConcurrency: LIVE_SETTINGS.livePrefetchConcurrency.default,
+    livePrefetchCacheMiB: LIVE_SETTINGS.livePrefetchCacheMiB.default,
     maxDepth: 20,
     schemaVersion: SCHEMA_VERSION
   });
@@ -167,6 +187,23 @@
     if (THEME_MODES.indexOf(merged.theme) === -1) {
       merged.theme = DEFAULT_CONFIG.theme;
     }
+    if (LIVE_SETTINGS.liveProtocolPreference.values.indexOf(merged.liveProtocolPreference) === -1) {
+      merged.liveProtocolPreference = LIVE_SETTINGS.liveProtocolPreference.default;
+    }
+    if (typeof merged.livePrefetchEnabled !== "boolean") {
+      merged.livePrefetchEnabled = LIVE_SETTINGS.livePrefetchEnabled.default;
+    }
+    ["livePrefetchTargetSeconds", "livePrefetchMaxSegments",
+      "livePrefetchConcurrency", "livePrefetchCacheMiB"].forEach(function normalizeLiveNumber(key) {
+      const setting = LIVE_SETTINGS[key];
+      const value = merged[key];
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        merged[key] = setting.default;
+        return;
+      }
+      const clamped = Math.min(setting.max, Math.max(setting.min, value));
+      merged[key] = setting.min + Math.round((clamped - setting.min) / setting.step) * setting.step;
+    });
     merged.schemaVersion = SCHEMA_VERSION;
     return merged;
   }
@@ -672,6 +709,7 @@
     CANDIDATE_POOL,
     ACCENT_KEYS,
     THEME_MODES,
+    LIVE_SETTINGS,
     DEFAULT_CONFIG,
     normalizeConfig,
     hasMediaSignal: hasBiliMediaSignal,

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -37,6 +37,45 @@
   const nativeJsonParse = JSON.parse;
   const nativeFetch = root.fetch;
   const NativeXHR = root.XMLHttpRequest;
+  const NativeResponse = root.Response;
+  const NativeAbortController = root.AbortController;
+  const NativeReadableStream = root.ReadableStream;
+  const NativeTextDecoder = root.TextDecoder;
+  const liveCore = root.BiliAcceleratorLiveStability;
+  const liveRuntimeModule = root.BiliAcceleratorLiveRuntime;
+
+  function isSupportedLiveBrowser() {
+    try {
+      const navigator = root.navigator || {};
+      const ua = String(navigator.userAgent || "");
+      const excluded = /(?:OPR\/|Opera|Vivaldi|YaBrowser|Brave)/i.test(ua) || Boolean(navigator.brave);
+      if (excluded) {
+        return false;
+      }
+      const brands = navigator.userAgentData && navigator.userAgentData.brands;
+      if (!Array.isArray(brands)) {
+        return false;
+      }
+      const names = brands.map(function brandName(item) { return String(item && item.brand || ""); });
+      if (names.some(function excludedBrand(name) { return /Opera|Vivaldi|YaBrowser|Brave/i.test(name); })) {
+        return false;
+      }
+      return names.some(function supportedBrand(name) { return /Google Chrome|Microsoft Edge/i.test(name); });
+    } catch (_) {
+      return false;
+    }
+  }
+
+  const liveIntegrationSupported = Boolean(liveCore && liveRuntimeModule &&
+    typeof nativeFetch === "function" &&
+    typeof NativeResponse === "function" &&
+    typeof NativeAbortController === "function" &&
+    typeof NativeReadableStream === "function" &&
+    typeof NativeTextDecoder === "function" &&
+    typeof liveCore.transformPlayInfo === "function" &&
+    typeof liveCore.classifyRequest === "function" &&
+    typeof liveRuntimeModule.createLivePrefetchRuntime === "function" &&
+    isSupportedLiveBrowser());
 
   let immersive = false;
   let revealTimer = null;
@@ -59,6 +98,7 @@
     recoveries: 0,
     p2pBlocked: 0,
     ranking: [],
+    livePrefetchMetrics: [],
     probedAt: null,
     installedAt: new Date().toISOString()
   };
@@ -76,14 +116,49 @@
   }
 
   let config = loadConfig();
+  let liveRuntime = null;
+  let livePlan = [];
+  let livePlanKey = "[]";
+  let liveConfigKey = "";
+  let liveRuntimePaused = Boolean(document.hidden);
+
+  function livePolicyKey(value) {
+    return JSON.stringify({
+      enabled: value.enabled,
+      mode: value.mode,
+      liveProtocolPreference: value.liveProtocolPreference,
+      livePrefetchEnabled: value.livePrefetchEnabled,
+      livePrefetchTargetSeconds: value.livePrefetchTargetSeconds,
+      livePrefetchMaxSegments: value.livePrefetchMaxSegments,
+      livePrefetchConcurrency: value.livePrefetchConcurrency,
+      livePrefetchCacheMiB: value.livePrefetchCacheMiB
+    });
+  }
+
+  function configureLiveRuntime(force) {
+    if (!liveRuntime || liveRuntimePaused) {
+      return;
+    }
+    const nextKey = livePolicyKey(config);
+    if (!force && nextKey === liveConfigKey) {
+      return;
+    }
+    liveConfigKey = nextKey;
+    liveRuntime.configure({ policy: config, plan: livePlan });
+  }
 
   function saveConfig(nextConfig) {
+    const previousLiveKey = livePolicyKey(config);
     config = core.normalizeConfig(nextConfig);
     try {
       root.localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
     } catch (_) {
       // storage may be unavailable; in-memory config still applies.
     }
+    if (previousLiveKey !== livePolicyKey(config)) {
+      configureLiveRuntime(false);
+    }
+    updateLiveControls();
   }
 
   // ---- panel appearance ---------------------------------------------------
@@ -348,13 +423,18 @@
   function mergeBackups(entry, key, base) {
     const alts = core.alternativesFor(base, config, backupPool());
     if (!alts.length) {
-      return;
+      return false;
     }
     const existing = Array.isArray(entry[key]) ? entry[key] : [];
     const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
       return arr.indexOf(u) === i;
     });
-    entry[key] = merged.slice(0, 8);
+    const next = merged.slice(0, 8);
+    if (next.length === existing.length && next.every(function same(value, index) { return value === existing[index]; })) {
+      return false;
+    }
+    entry[key] = next;
+    return true;
   }
 
   // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
@@ -364,9 +444,11 @@
   // uses camelCase (baseUrl/backupUrl); app-style payloads and durl use
   // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
-    if (config.selection !== "auto" || !payload || typeof payload !== "object") {
-      return;
+    if (!config.enabled || config.mode === "off" || config.selection !== "auto" ||
+        !payload || typeof payload !== "object") {
+      return false;
     }
+    let changed = false;
     const containers = [
       payload.data,
       payload.result,
@@ -377,15 +459,17 @@
       if (!container || typeof container !== "object") {
         return;
       }
-      enrichDash(container.dash);
-      enrichDurl(container.durl);
+      changed = enrichDash(container.dash) || changed;
+      changed = enrichDurl(container.durl) || changed;
     });
+    return changed;
   }
 
   function enrichDash(dash) {
     if (!dash || typeof dash !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     ["video", "audio"].forEach(function eachKind(kind) {
       const list = dash[kind];
       if (!Array.isArray(list)) {
@@ -396,52 +480,76 @@
           return;
         }
         if (typeof entry.baseUrl === "string") {
-          mergeBackups(entry, "backupUrl", entry.baseUrl);
+          changed = mergeBackups(entry, "backupUrl", entry.baseUrl) || changed;
         }
         if (typeof entry.base_url === "string") {
-          mergeBackups(entry, "backup_url", entry.base_url);
+          changed = mergeBackups(entry, "backup_url", entry.base_url) || changed;
         }
       });
     });
+    return changed;
   }
 
   function enrichDurl(durl) {
     if (!Array.isArray(durl)) {
-      return;
+      return false;
     }
+    let changed = false;
     durl.forEach(function eachEntry(entry) {
       if (entry && typeof entry.url === "string") {
-        mergeBackups(entry, "backup_url", entry.url);
+        changed = mergeBackups(entry, "backup_url", entry.url) || changed;
       }
     });
+    return changed;
+  }
+
+  function updateLivePlan(result) {
+    if (!liveRuntime || !result || !result.matched) {
+      return;
+    }
+    const nextPlan = Array.isArray(result.plan) ? result.plan : [];
+    const nextKey = JSON.stringify(nextPlan);
+    if (nextKey === livePlanKey) {
+      return;
+    }
+    livePlan = nextPlan;
+    livePlanKey = nextKey;
+    configureLiveRuntime(true);
+  }
+
+  function processPayload(payload, source) {
+    const tracker = { changed: false, rewrites: [] };
+    const empty = { payload, changed: false, rewrites: [], plan: [], matched: false };
+    if (!config.enabled || config.mode === "off") {
+      return empty;
+    }
+    try {
+      const rewritten = core.rewriteObject(payload, config, tracker);
+      const backupsChanged = enrichBackups(rewritten);
+      const filtered = core.filterLiveUrlInfo(rewritten, config);
+      const transformed = liveIntegrationSupported
+        ? liveCore.transformPlayInfo(rewritten, config)
+        : { changed: false, rewrites: [], plan: [], matched: false };
+      const rewrites = tracker.rewrites.concat(filtered.rewrites || [], transformed.rewrites || []);
+      const result = {
+        payload: rewritten,
+        changed: Boolean(tracker.changed || backupsChanged || filtered.changed || transformed.changed),
+        rewrites,
+        plan: transformed.plan || [],
+        matched: Boolean(transformed.matched)
+      };
+      record(rewrites, source);
+      rememberSample(rewritten);
+      updateLivePlan(result);
+      return result;
+    } catch (error) {
+      console.warn("[BiliAccelerator] rewrite failed", error);
+      return empty;
+    }
   }
 
   function rewritePayload(payload, source) {
-    const tracker = { changed: false, rewrites: [] };
-    try {
-      const rewritten = core.rewriteObject(payload, config, tracker);
-      enrichBackups(rewritten);
-      record(tracker.rewrites, source);
-      filterLivePcdn(rewritten, source);
-      rememberSample(rewritten);
-      return rewritten;
-    } catch (error) {
-      console.warn("[BiliAccelerator] rewrite failed", error);
-      return payload;
-    }
-  }
-
-  // Live playurl payloads list candidate hosts (url_info) instead of full URLs;
-  // drop the PCDN/MCDN entries so the live player only ever dials official CDN.
-  function filterLivePcdn(payload, source) {
-    try {
-      const filtered = core.filterLiveUrlInfo(payload, config);
-      if (filtered.changed) {
-        record(filtered.rewrites, source);
-      }
-    } catch (_) {
-      // never let live filtering break payload delivery.
-    }
+    return processPayload(payload, source).payload;
   }
 
   // Quick check on a response body: does it plausibly carry media URLs?
@@ -452,6 +560,7 @@
         text.indexOf("mcdn") !== -1 ||
         text.indexOf("upgcxcode") !== -1 ||
         text.indexOf("os=mcdn") !== -1 ||
+        text.indexOf("playurl_info") !== -1 ||
         text.indexOf("akamaized") !== -1);
   }
 
@@ -507,7 +616,7 @@
   function patchJsonParse() {
     JSON.parse = function patchedJsonParse(text) {
       const parsed = nativeJsonParse.apply(this, arguments);
-      if (config.enabled && bodyHasSignal(text)) {
+      if (config.enabled && config.mode !== "off" && bodyHasSignal(text)) {
         return rewritePayload(parsed, "JSON.parse");
       }
       return parsed;
@@ -534,8 +643,23 @@
     root.fetch = function patchedFetch(input, init) {
       let args = arguments;
       const reqUrl = requestUrlOf(input);
-      const isMedia = !!reqUrl && core.hasMediaSignal(reqUrl);
-      if (config.enabled && isMedia) {
+      let liveMeta = null;
+      if (liveRuntime && config.enabled && config.mode !== "off") {
+        try {
+          liveMeta = liveCore.classifyRequest(input, init);
+          liveMeta.transport = "fetch";
+          liveMeta.bufferedSeconds = currentBufferedSeconds();
+          const cached = liveRuntime.beforeFetch(liveMeta);
+          if (cached) {
+            return Promise.resolve(cached);
+          }
+        } catch (_) {
+          liveMeta = null;
+        }
+      }
+      const isMedia = Boolean((reqUrl && core.hasMediaSignal(reqUrl)) ||
+        (liveMeta && (liveMeta.kind === "playlist" || liveMeta.kind === "segment" || liveMeta.kind === "flv")));
+      if (config.enabled && config.mode !== "off" && reqUrl && core.hasMediaSignal(reqUrl)) {
         const swapped = rewriteRequestUrl(reqUrl);
         if (swapped !== reqUrl) {
           // string and URL inputs can be replaced by the string directly; only a
@@ -548,7 +672,13 @@
       }
 
       return nativeFetch.apply(this, args).then(function handleResponse(response) {
-        if (!config.enabled) {
+        if (liveRuntime && liveMeta) {
+          try { liveRuntime.observeResponse(liveMeta, response); } catch (_) {}
+        }
+        if (isMedia && liveMeta && (liveMeta.kind === "flv" || liveMeta.kind === "segment")) {
+          return response;
+        }
+        if (!config.enabled || config.mode === "off") {
           return response;
         }
         const contentType = response.headers && response.headers.get("content-type");
@@ -560,7 +690,7 @@
         // player's response for the optional speed graph can then interfere with
         // MSE playback. XHR transfers are still measured below, and fetch-based
         // playback falls back to the buffer-ahead graph.
-        if (isMedia && isBinary) {
+        if (isMedia) {
           return response;
         }
 
@@ -571,27 +701,18 @@
           if (!bodyHasSignal(text)) {
             return response;
           }
-          let parsed;
-          const tracker = { changed: false, rewrites: [] };
-          let live = { changed: false, rewrites: [] };
+          let result;
           try {
-            parsed = nativeJsonParse(text);
-            core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
-            live = core.filterLiveUrlInfo(parsed, config);
+            result = processPayload(nativeJsonParse(text), "fetch");
           } catch (_) {
             return response;
           }
-          if (!tracker.changed && !live.changed) {
-            rememberSample(parsed);
+          if (!result.changed) {
             return response;
           }
-          record(tracker.rewrites, "fetch");
-          record(live.rewrites, "fetch");
-          rememberSample(parsed);
           const headers = new Headers(response.headers);
           headers.delete("content-length");
-          return new Response(JSON.stringify(parsed), {
+          return new NativeResponse(JSON.stringify(result.payload), {
             status: response.status,
             statusText: response.statusText,
             headers
@@ -619,7 +740,7 @@
         : (url && typeof url.href === "string" ? url.href : "");
       this.__baAccel = { url: urlStr };
       let finalUrl = url;
-      if (config.enabled && urlStr && core.hasMediaSignal(urlStr)) {
+      if (config.enabled && config.mode !== "off" && urlStr && core.hasMediaSignal(urlStr)) {
         finalUrl = rewriteRequestUrl(urlStr);
       }
       return open.apply(this, [method, finalUrl].concat([].slice.call(arguments, 2)));
@@ -636,7 +757,7 @@
 
       // Count downloaded bytes for media segments (free via loadend.loaded) and
       // time send→loadend as the transfer duration for the throughput window.
-      if (config.enabled && isMedia) {
+      if (config.enabled && config.mode !== "off" && isMedia) {
         const startTs = nowMs();
         xhr.addEventListener("loadend", function onLoadEnd(event) {
           if (event && typeof event.loaded === "number") {
@@ -645,26 +766,24 @@
         });
       }
 
-      if (config.enabled && interesting) {
+      if (config.enabled && config.mode !== "off" && interesting && !isMedia) {
         xhr.addEventListener("load", function onLoad() {
           try {
             const ct = xhr.getResponseHeader && xhr.getResponseHeader("content-type");
             if (ct && !ct.includes("json") && !ct.includes("text")) {
               return;
             }
-            const text = xhr.responseText;
+            const jsonResponse = xhr.responseType === "json";
+            const original = jsonResponse ? xhr.response : xhr.responseText;
+            const text = jsonResponse ? JSON.stringify(original) : original;
             if (!bodyHasSignal(text)) {
               return;
             }
-            const parsed = nativeJsonParse(text);
-            const tracker = { changed: false, rewrites: [] };
-            core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
-            const live = core.filterLiveUrlInfo(parsed, config);
-            rememberSample(parsed);
-            if (!tracker.changed && !live.changed) {
+            const result = processPayload(jsonResponse ? original : nativeJsonParse(text), "xhr");
+            if (!result.changed) {
               return;
             }
+            const parsed = result.payload;
             const rewrittenText = JSON.stringify(parsed);
             const shim = {
               configurable: true,
@@ -679,8 +798,6 @@
                 }
               });
             } catch (_) {}
-            record(tracker.rewrites, "xhr");
-            record(live.rewrites, "xhr");
           } catch (_) {
             // leave the original response intact on any failure.
           }
@@ -938,6 +1055,22 @@
     return null;
   }
 
+  function currentBufferedSeconds() {
+    const video = watchedVideo || (document.querySelector && document.querySelector("video"));
+    try {
+      if (!video || !video.buffered || !video.buffered.length) {
+        return null;
+      }
+      const current = Number(video.currentTime) || 0;
+      for (let i = 0; i < video.buffered.length; i += 1) {
+        if (video.buffered.start(i) <= current && video.buffered.end(i) >= current) {
+          return Math.max(0, video.buffered.end(i) - current);
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
   function handleStall() {
     // Browsers throttle media/MSE work in background tabs, which can make the
     // player emit a transient waiting/stalled event. Rotating CDN hosts in that
@@ -997,12 +1130,19 @@
 
   function onVisibilityChange() {
     if (document.hidden) {
+      liveRuntimePaused = true;
+      if (liveRuntime) {
+        liveRuntime.reset("hidden");
+      }
       if (stallTimer) {
         clearTimeout(stallTimer);
         stallTimer = null;
       }
       return;
     }
+
+    liveRuntimePaused = false;
+    configureLiveRuntime(true);
 
     // A waiting event fired while hidden is deliberately ignored. Re-evaluate
     // once foregrounded so a genuine, still-active stall keeps the normal grace
@@ -1021,6 +1161,11 @@
     const video = document.querySelector("video");
     if (!video || video === watchedVideo) {
       return;
+    }
+
+    if (watchedVideo && liveRuntime) {
+      liveRuntime.reset("video-replaced");
+      configureLiveRuntime(true);
     }
     watchedVideo = video;
     video.addEventListener("waiting", onWaiting, { passive: true });
@@ -1046,7 +1191,8 @@
       },
       ranking: state.ranking,
       probedAt: state.probedAt,
-      recentRewrites: state.rewrites.slice(-15)
+      recentRewrites: state.rewrites.slice(-15),
+      livePrefetch: state.livePrefetchMetrics.slice(-15)
     };
   }
 
@@ -1407,15 +1553,7 @@
     setBadgeHidden(immersive && !panelIsOpen());
   }
 
-  // Live rooms run a different player: no .bpx-player-container, no data-screen,
-  // nothing detectScreenMode() can read (checked against a real room — a live
-  // page has zero bpx-* elements). Without this the badge sits permanently over
-  // the chat column.
-  //
-  // Kept separate from detectScreenMode() on purpose. That function answers
-  // "what screen mode is the player in", and answering "web" for a live page
-  // would also satisfy the setLifted() test below, nudging the badge to
-  // bottom:84px on every live page as a side effect.
+  // Live rooms use a different player without the usual screen-mode markers.
   function isLivePage() {
     const host = root.location && typeof root.location.hostname === "string"
       ? root.location.hostname.toLowerCase()
@@ -1482,7 +1620,6 @@
     document.addEventListener("mousemove", handlePointerMove, { passive: true });
     document.addEventListener("fullscreenchange", refreshImmersive);
     document.addEventListener("webkitfullscreenchange", refreshImmersive);
-    document.addEventListener("visibilitychange", onVisibilityChange);
     ensurePlayerObserver();
     setInterval(ensurePlayerObserver, 1500);
   }
@@ -1526,6 +1663,11 @@
       stallTitle: "Auto-recover", stallNote: "Switch servers live if it stalls — no reload",
       akamaiTitle: "Rewrite Akamai", akamaiNote: "Only if Akamai is slow on your network",
       p2pTitle: "Stop bandwidth sharing", p2pNote: "Block Bilibili's P2P upload (reload to apply)",
+      liveProtocol: "Live protocol", liveProtocolOriginal: "Bilibili default",
+      liveProtocolStable: "Stable first (experimental)",
+      livePrefetchTitle: "Live prefetch", livePrefetchNote: "Read a few upcoming live segments",
+      liveTargetSeconds: "Target seconds", liveMaxSegments: "Max segments",
+      liveConcurrency: "Concurrent reads", liveCacheMiB: "Cache (MiB)",
       diag: "Copy report", diagCopied: "Copied ✓", diagConsole: "See console",
       reload: "Reload"
     },
@@ -1565,10 +1707,19 @@
       stallTitle: "自动恢复", stallNote: "卡顿时实时切换服务器，无需刷新",
       akamaiTitle: "改写 Akamai", akamaiNote: "仅当 Akamai 在你的网络上很慢时使用",
       p2pTitle: "停止带宽共享", p2pNote: "阻止 B 站的 P2P 上传（刷新后生效）",
+      liveProtocol: "直播协议", liveProtocolOriginal: "B 站默认",
+      liveProtocolStable: "稳定优先（实验）",
+      livePrefetchTitle: "直播预读取", livePrefetchNote: "提前读取少量后续直播分片",
+      liveTargetSeconds: "目标秒数", liveMaxSegments: "最大分片数",
+      liveConcurrency: "并发读取数", liveCacheMiB: "缓存（MiB）",
       diag: "复制诊断报告", diagCopied: "已复制 ✓", diagConsole: "见控制台",
       reload: "刷新"
     }
   };
+  const LIVE_PROTOCOL_I18N = Object.freeze({
+    original: "liveProtocolOriginal",
+    stable: "liveProtocolStable"
+  });
 
   function lang() {
     return config.lang === "zh" ? "zh" : "en";
@@ -1581,6 +1732,29 @@
   function getShadow() {
     const host = document.getElementById(BUTTON_ID);
     return host && host.shadowRoot;
+  }
+
+  function updateLiveControls() {
+    const shadow = getShadow();
+    if (!shadow || !liveIntegrationSupported) {
+      return;
+    }
+    const protocol = shadow.getElementById("ba-live-protocol");
+    const prefetch = shadow.getElementById("ba-live-prefetch");
+    if (protocol) {
+      protocol.value = config.liveProtocolPreference;
+    }
+    if (prefetch) {
+      prefetch.checked = config.livePrefetchEnabled;
+    }
+    ["livePrefetchTargetSeconds", "livePrefetchMaxSegments",
+      "livePrefetchConcurrency", "livePrefetchCacheMiB"].forEach(function updateNumber(key) {
+      const input = shadow.getElementById("ba-" + key);
+      if (input) {
+        input.value = String(config[key]);
+        input.disabled = !config.livePrefetchEnabled;
+      }
+    });
   }
 
   function currentStatusKey() {
@@ -1687,6 +1861,25 @@
     label.appendChild(caption);
     label.appendChild(control);
     return label;
+  }
+
+  function createLiveNumberInput(key, onChange) {
+    const setting = core.LIVE_SETTINGS[key];
+    const input = document.createElement("input");
+    input.type = "number";
+    input.className = "ba-control ba-live-number";
+    input.id = "ba-" + key;
+    input.value = String(config[key]);
+    input.min = String(setting.min);
+    input.max = String(setting.max);
+    input.step = String(setting.step);
+    input.disabled = !config.livePrefetchEnabled;
+    input.addEventListener("change", function () {
+      const rawValue = String(input.value || "").trim();
+      onChange(rawValue === "" ? setting.default : Number(rawValue));
+      input.value = String(config[key]);
+    });
+    return input;
   }
 
   // Like createField but a plain <div> instead of <label>, so a row of buttons
@@ -1868,7 +2061,8 @@
       ".ba-adv.open{display:block}",
       ".ba-field{display:grid;grid-template-columns:96px 1fr;align-items:center;gap:9px;margin:9px 0;font-size:12px}",
       ".ba-field span{color:var(--ba-ink-mid);font-weight:650}",
-      ".ba-control,.ba-field input[type=text],.ba-field select{width:100%;min-width:0;height:32px;border:1px solid var(--ba-border-in);border-radius:8px;padding:0 9px;background:var(--ba-card);color:var(--ba-ink);outline:none;font-size:11px}",
+      ".ba-control,.ba-field input[type=text],.ba-field input[type=number],.ba-field select{width:100%;min-width:0;height:32px;border:1px solid var(--ba-border-in);border-radius:8px;padding:0 9px;background:var(--ba-card);color:var(--ba-ink);outline:none;font-size:11px}",
+      ".ba-control:disabled,.ba-switch-row:has(input:disabled){opacity:.5;cursor:not-allowed}",
       ".ba-swatches{display:flex;align-items:center;gap:7px;min-height:32px;flex-wrap:wrap}",
       ".ba-sw{width:22px;height:22px;border-radius:50%;padding:0;border:none;cursor:pointer;box-shadow:0 0 0 1px var(--ba-border-in) inset;transition:transform .12s ease}",
       ".ba-sw:hover{transform:scale(1.12)}",
@@ -2080,6 +2274,42 @@
         saveConfig(Object.assign({}, config, { p2pGuard: checked }));
       });
 
+    const liveControls = [];
+    if (liveIntegrationSupported) {
+      const liveProtocolOptions = core.LIVE_SETTINGS.liveProtocolPreference.values.map(function liveProtocolOption(value) {
+        return { value, key: LIVE_PROTOCOL_I18N[value] };
+      });
+      const liveProtocol = createSelect(liveProtocolOptions, config.liveProtocolPreference, function (value) {
+        saveConfig(Object.assign({}, config, { liveProtocolPreference: value }));
+      });
+      liveProtocol.id = "ba-live-protocol";
+      liveControls.push(createField("liveProtocol", liveProtocol));
+
+      const numberKeys = [
+        ["livePrefetchTargetSeconds", "liveTargetSeconds"],
+        ["livePrefetchMaxSegments", "liveMaxSegments"],
+        ["livePrefetchConcurrency", "liveConcurrency"],
+        ["livePrefetchCacheMiB", "liveCacheMiB"]
+      ];
+      const numberInputs = numberKeys.map(function makeLiveNumber(item) {
+        const key = item[0];
+        const input = createLiveNumberInput(key, function (value) {
+          const next = {};
+          next[key] = value;
+          saveConfig(Object.assign({}, config, next));
+        });
+        liveControls.push(createField(item[1], input));
+        return input;
+      });
+      const prefetchRow = createSwitchRow("livePrefetchTitle", "livePrefetchNote",
+        config.livePrefetchEnabled, function (checked) {
+          saveConfig(Object.assign({}, config, { livePrefetchEnabled: checked }));
+          numberInputs.forEach(function updateDisabled(input) { input.disabled = !checked; });
+        });
+      prefetchRow.querySelector("input").id = "ba-live-prefetch";
+      liveControls.splice(1, 0, prefetchRow);
+    }
+
     const diag = document.createElement("button");
     diag.type = "button";
     diag.dataset.i18n = "diag";
@@ -2118,6 +2348,7 @@
     adv.appendChild(stallRow);
     adv.appendChild(akamaiRow);
     adv.appendChild(p2pRow);
+    liveControls.forEach(function appendLiveControl(control) { adv.appendChild(control); });
     adv.appendChild(actions);
 
     // Scrollable body holds everything; the advanced toggle is pinned below it
@@ -2180,12 +2411,52 @@
     shadow.appendChild(panel);
     shadow.appendChild(toggle);
     document.documentElement.appendChild(host);
+    updateLiveControls();
     applyLang();
     applyTheme();
     watchSystemTheme();
   }
 
   // ---- external config bridge (extension popup → page) -------------------
+
+  function installLiveRuntime() {
+    if (!liveIntegrationSupported || liveRuntime) {
+      return;
+    }
+    try {
+      liveRuntime = liveRuntimeModule.createLivePrefetchRuntime({
+        LiveCore: liveCore,
+        nativeFetch: typeof nativeFetch === "function"
+          ? function runtimeFetch(input, init) { return nativeFetch.call(root, input, init); }
+          : null,
+        createResponse: typeof NativeResponse === "function"
+          ? function createRuntimeResponse(body, init) { return new NativeResponse(body, init); }
+          : null,
+        createAbortController: typeof NativeAbortController === "function"
+          ? function createRuntimeController() { return new NativeAbortController(); }
+          : null,
+        ReadableStream: NativeReadableStream,
+        TextDecoder: NativeTextDecoder,
+        getBufferedSeconds: currentBufferedSeconds,
+        onMetric: function rememberLiveMetric(metric) {
+          state.livePrefetchMetrics.push({
+            host: String(metric && metric.host || ""),
+            sequence: metric && metric.sequence,
+            bytes: Math.max(0, Number(metric && metric.bytes) || 0),
+            reason: String(metric && metric.reason || "")
+          });
+          state.livePrefetchMetrics = state.livePrefetchMetrics.slice(-50);
+        }
+      });
+      configureLiveRuntime(true);
+      if (typeof root.addEventListener === "function") {
+        root.addEventListener("pagehide", function () { liveRuntime.reset("pagehide"); });
+        root.addEventListener("unload", function () { liveRuntime.dispose(); });
+      }
+    } catch (_) {
+      liveRuntime = null;
+    }
+  }
 
   function installConfigBridge() {
     if (typeof root.addEventListener !== "function") {
@@ -2198,6 +2469,7 @@
       const data = event.data;
       if (data && data.__biliAccel === "config" && data.config) {
         saveConfig(Object.assign({}, config, data.config));
+        updateLiveControls();
         applyLang();
         applyTheme();
       }
@@ -2206,7 +2478,7 @@
 
   root.BiliAccelerator = {
     getConfig: function () { return Object.assign({}, config); },
-    setConfig: function (next) { saveConfig(Object.assign({}, config, next || {})); renderStatus(); applyTheme(); return this.getConfig(); },
+    setConfig: function (next) { saveConfig(Object.assign({}, config, next || {})); updateLiveControls(); renderStatus(); applyTheme(); return this.getConfig(); },
     getStats: function () { return JSON.parse(JSON.stringify(state)); },
     getDiagnostics: function () { return buildDiagnostics(); },
     rewriteUrl: function (url) { return core.rewriteUrl(url, config); }
@@ -2214,6 +2486,7 @@
 
   const bootRanking = loadRanking();
   applyRanking(bootRanking && bootRanking.ranking);
+  installLiveRuntime();
   patchJsonParse();
   patchFetch();
   patchXHR();
@@ -2222,6 +2495,7 @@
   patchGlobalPlayInfo("__NEPTUNE_IS_MY_WAIFU__"); // live room initial state
   installP2PGuard();
   installConfigBridge();
+  document.addEventListener("visibilitychange", onVisibilityChange);
 
   function bootstrapUi() {
     installUi();

--- a/src/page/live-stability.runtime.js
+++ b/src/page/live-stability.runtime.js
@@ -1,0 +1,1092 @@
+(function initBiliAcceleratorLiveRuntime(root, factory) {
+  const LiveCore = typeof module === "object" && module.exports
+    ? require("../core/live-stability")
+    : root.BiliAcceleratorLiveStability;
+  const runtime = factory(LiveCore);
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = runtime;
+  }
+
+  root.BiliAcceleratorLiveRuntime = runtime;
+})(typeof globalThis !== "undefined" ? globalThis : window, function createRuntimeModule(defaultLiveCore) {
+  "use strict";
+
+  const hasOwn = Object.prototype.hasOwnProperty;
+  const SAFE_REQUEST_HEADERS = Object.freeze({
+    accept: true,
+    "accept-language": true,
+    "content-language": true,
+    "content-type": true
+  });
+  const UNSAFE_RESPONSE_HEADERS = Object.freeze({
+    "content-encoding": true,
+    "content-length": true,
+    "set-cookie": true,
+    "set-cookie2": true,
+    "transfer-encoding": true
+  });
+
+  function isHlsUrl(value) {
+    try {
+      const url = new URL(value);
+      return (url.protocol === "http:" || url.protocol === "https:") &&
+        url.pathname.toLowerCase().endsWith(".m3u8");
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isBilibiliLiveFmp4Url(value) {
+    try {
+      const url = new URL(value);
+      return /(?:^|\.)bilivideo\.com$/i.test(url.hostname) &&
+        url.pathname.includes("/live-bvc/") && url.pathname.toLowerCase().endsWith(".m4s");
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function responseHeader(response, name) {
+    try {
+      return response && response.headers && typeof response.headers.get === "function"
+        ? response.headers.get(name)
+        : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function safeResponseInit(response) {
+    const headers = {};
+    try {
+      if (response.headers && typeof response.headers.forEach === "function") {
+        response.headers.forEach(function copy(value, name) {
+          const key = String(name).toLowerCase();
+          if (!UNSAFE_RESPONSE_HEADERS[key]) {
+            headers[key] = String(value);
+          }
+        });
+      }
+    } catch (_) {
+      // A response with inaccessible headers can still be represented safely.
+    }
+    return { status: 200, statusText: String(response.statusText || "OK"), headers };
+  }
+
+  function createLivePrefetchRuntime(adapter) {
+    const dependencies = adapter || {};
+    const LiveCore = dependencies.LiveCore || defaultLiveCore;
+    const nativeFetch = dependencies.nativeFetch || dependencies.fetch;
+    const createController = typeof dependencies.createAbortController === "function"
+      ? dependencies.createAbortController
+      : typeof dependencies.AbortController === "function"
+        ? function newController() { return new dependencies.AbortController(); }
+        : null;
+    const createResponse = typeof dependencies.createResponse === "function"
+      ? dependencies.createResponse
+      : null;
+    const ReadableStreamImpl = hasOwn.call(dependencies, "ReadableStream")
+      ? dependencies.ReadableStream
+      : null;
+    const TextDecoderImpl = hasOwn.call(dependencies, "TextDecoder")
+      ? dependencies.TextDecoder
+      : null;
+    const onMetric = typeof dependencies.onMetric === "function" ? dependencies.onMetric : function noop() {};
+
+    let generation = 0;
+    let enabled = false;
+    let disposed = false;
+    let policy = LiveCore.normalizePolicy({});
+    let configurationKey = "";
+    let roots = new Set();
+    let activeRoot = null;
+    let trustedPlaylists = new Set();
+    let playlistReferences = new Map();
+    let playlistVariantReferences = new Map();
+    let playlistMediaReferences = new Map();
+    let activeVariants = new Map();
+    let activeVariantOrders = new Map();
+    let variantRequestCounter = 0;
+    let playlistRevisions = new Map();
+    let playlistRevisionCounter = 0;
+    let activePlaylistReads = new Set();
+    let activePlaylistBytes = 0;
+    let snapshots = new Map();
+    let knownSegments = new Map();
+    let failedUrls = new Set();
+    let queue = [];
+    let inFlight = new Map();
+    let cache = new Map();
+    let cachedBytes = 0;
+    let delivered = new Set();
+    let deliveredBytes = 0;
+    const requestBindings = new WeakMap();
+    let rootRequestCounter = 0;
+    let latestRootRequestOrder = 0;
+
+    function metric(entry, reason, bytes) {
+      let host = "";
+      try { host = new URL(entry.url).host; } catch (_) { /* omit malformed hosts */ }
+      try {
+        onMetric({
+          type: "live-prefetch",
+          host,
+          sequence: entry.sequence,
+          bytes: Math.max(0, Number(bytes) || 0),
+          reason
+        });
+      } catch (_) {
+        // Telemetry cannot affect playback or prefetch state.
+      }
+    }
+
+    function abortEntry(entry, reason) {
+      if (!entry) {
+        return;
+      }
+      entry.abortReason = reason;
+      try { entry.controller.abort(); } catch (_) { /* already aborted */ }
+    }
+
+    function clearRuntimeState(reason) {
+      generation += 1;
+      latestRootRequestOrder = 0;
+      queue.forEach(function abortQueued(entry) { abortEntry(entry, reason); });
+      inFlight.forEach(function abortActive(entry) { abortEntry(entry, reason); });
+      queue = [];
+      cache.clear();
+      cachedBytes = 0;
+      trustedPlaylists.clear();
+      playlistReferences.clear();
+      playlistVariantReferences.clear();
+      playlistMediaReferences.clear();
+      activeVariants.clear();
+      activeVariantOrders.clear();
+      playlistRevisions.clear();
+      activePlaylistReads.forEach(cancelPlaylistRead);
+      snapshots.clear();
+      knownSegments.clear();
+      failedUrls.clear();
+    }
+
+    function normalizeMeta(meta) {
+      try {
+        if (!meta) {
+          return null;
+        }
+        if (typeof meta === "string" || meta instanceof URL) {
+          return LiveCore.classifyRequest(meta);
+        }
+        if (typeof meta.url !== "string") {
+          return null;
+        }
+        if (meta.fingerprint && meta.kind && meta.headers) {
+          return Object.assign({}, meta);
+        }
+        const classified = LiveCore.classifyRequest(meta.url, {
+          method: meta.method,
+          headers: meta.headers,
+          body: meta.body,
+          credentials: meta.credentials,
+          mode: meta.mode,
+          cache: meta.cache,
+          redirect: meta.redirect,
+          integrity: meta.integrity,
+          referrer: meta.referrer,
+          referrerPolicy: meta.referrerPolicy,
+          keepalive: meta.keepalive
+        });
+        ["transport", "source", "bufferedSeconds"].forEach(function preserve(key) {
+          if (hasOwn.call(meta, key)) {
+            classified[key] = meta[key];
+          }
+        });
+        return classified;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function bindRequest(rawMeta, meta) {
+      let rootOrder = latestRootRequestOrder;
+      if (roots.has(meta.url)) {
+        rootOrder = ++rootRequestCounter;
+        latestRootRequestOrder = rootOrder;
+        if (enabled && !disposed) {
+          activateRoot(meta.url);
+        }
+      }
+      const variantOrders = enabled && !disposed ? activateVariantRequest(meta.url) : [];
+      const binding = { generation, enabled, rootOrder, variantOrders };
+      if (rawMeta && typeof rawMeta === "object") {
+        requestBindings.set(rawMeta, binding);
+      }
+      return binding;
+    }
+
+    function responseBinding(rawMeta) {
+      if (!rawMeta || typeof rawMeta !== "object") {
+        return null;
+      }
+      return requestBindings.get(rawMeta) || null;
+    }
+
+    function bindingIsCurrent(binding) {
+      return Boolean(binding && binding.enabled && binding.generation === generation &&
+        (!binding.rootOrder || binding.rootOrder === latestRootRequestOrder) &&
+        binding.variantOrders.every(function currentVariant(item) {
+          return activeVariants.get(item.parent) === item.url &&
+            activeVariantOrders.get(item.parent) === item.order;
+        }));
+    }
+
+    function isFetchMeta(meta) {
+      return !(meta && ((meta.transport && meta.transport !== "fetch") ||
+        (meta.source && meta.source !== "fetch")));
+    }
+
+    function isSafeGet(meta) {
+      return Boolean(meta && meta.method === "GET" &&
+        (meta.body === null || meta.body === undefined) && !meta.range &&
+        !meta.auth && !meta.customHeader && !meta.integrity && meta.redirect === "follow");
+    }
+
+    function safeRequestHeaders(meta) {
+      const headers = {};
+      Object.keys(meta.headers || {}).forEach(function copy(key) {
+        const normalized = String(key).toLowerCase();
+        if (SAFE_REQUEST_HEADERS[normalized]) {
+          headers[normalized] = String(meta.headers[key]);
+        }
+      });
+      return headers;
+    }
+
+    function requestForSegment(segment, sourceMeta) {
+      return LiveCore.classifyRequest(segment.url, {
+        method: "GET",
+        headers: safeRequestHeaders(sourceMeta),
+        credentials: sourceMeta.credentials,
+        mode: sourceMeta.mode,
+        cache: sourceMeta.cache,
+        redirect: sourceMeta.redirect,
+        integrity: sourceMeta.integrity,
+        referrer: sourceMeta.referrer,
+        referrerPolicy: sourceMeta.referrerPolicy,
+        keepalive: sourceMeta.keepalive
+      });
+    }
+
+    function bufferedSeconds(meta) {
+      if (meta && hasOwn.call(meta, "bufferedSeconds") && meta.bufferedSeconds !== null &&
+          meta.bufferedSeconds !== "" && Number.isFinite(Number(meta.bufferedSeconds))) {
+        return Math.max(0, Number(meta.bufferedSeconds));
+      }
+      if (typeof dependencies.getBufferedSeconds === "function") {
+        try {
+          const raw = dependencies.getBufferedSeconds(meta);
+          const value = Number(raw);
+          return raw !== null && raw !== "" && Number.isFinite(value) ? Math.max(0, value) : null;
+        } catch (_) {
+          return null;
+        }
+      }
+      return null;
+    }
+
+    function reservedBytes() {
+      let bytes = activePlaylistBytes + deliveredBytes;
+      inFlight.forEach(function add(entry) { bytes += entry.accountedBytes || 0; });
+      return bytes;
+    }
+
+    function ownedUrls() {
+      const values = new Set();
+      queue.forEach(function add(entry) { values.add(entry.url); });
+      inFlight.forEach(function add(entry) { values.add(entry.url); });
+      cache.forEach(function add(entry) { values.add(entry.url); });
+      delivered.forEach(function add(entry) { values.add(entry.url); });
+      return values;
+    }
+
+    function ownedDuration() {
+      let duration = 0;
+      queue.forEach(function add(entry) { duration += entry.duration || 0; });
+      inFlight.forEach(function add(entry) { duration += entry.duration || 0; });
+      cache.forEach(function add(entry) { duration += entry.duration || 0; });
+      delivered.forEach(function add(entry) { duration += entry.duration || 0; });
+      return duration;
+    }
+
+    function entryCount() {
+      return queue.length + inFlight.size + cache.size + delivered.size;
+    }
+
+    function responseIsUsable(response) {
+      if (!response || response.status !== 200 || response.ok !== true ||
+          response.type === "opaque" || response.redirected === true ||
+          responseHeader(response, "content-range")) {
+        return false;
+      }
+      const mime = String(responseHeader(response, "content-type") || "").split(";", 1)[0].trim().toLowerCase();
+      return !(/^text\//.test(mime) || /^application\/(?:json|problem\+json|xml)$/.test(mime) ||
+        /\+(?:json|xml)$/.test(mime) || mime === "application/xhtml+xml");
+    }
+
+    function urlIsInCurrentWindow(url) {
+      let present = false;
+      snapshots.forEach(function check(snapshot, playlistUrl) {
+        if (!present && trustedPlaylists.has(playlistUrl) && snapshot.playlist.segments.some(function matches(segment) {
+          return segment.url === url;
+        })) {
+          present = true;
+        }
+      });
+      return present;
+    }
+
+    function pruneFailedUrls() {
+      failedUrls.forEach(function remove(url) {
+        if (!urlIsInCurrentWindow(url)) {
+          failedUrls.delete(url);
+        }
+      });
+    }
+
+    async function readOwnedResponse(response, entry, byteLimit) {
+      const lengthHeader = responseHeader(response, "content-length");
+      const declared = lengthHeader !== null && /^\d+$/.test(String(lengthHeader).trim())
+        ? Number(lengthHeader)
+        : null;
+      if (declared !== null) {
+        if (!Number.isSafeInteger(declared) || declared < 0) {
+          throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+        }
+        if (declared === 0) {
+          throw Object.assign(new Error("empty body"), { code: "EMPTY_BODY" });
+        }
+        entry.accountedBytes = declared;
+        if (cachedBytes + reservedBytes() > byteLimit) {
+          entry.accountedBytes = 0;
+          throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+        }
+      }
+
+      const chunks = [];
+      let total = 0;
+      const reader = response.body && typeof response.body.getReader === "function"
+        ? response.body.getReader()
+        : null;
+      if (!reader) {
+        if (declared === null) {
+          throw Object.assign(new Error("stream required"), { code: "BODY_STREAM_REQUIRED" });
+        }
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        total = bytes.byteLength;
+        entry.accountedBytes = total;
+        if (cachedBytes + reservedBytes() > byteLimit) {
+          entry.accountedBytes = 0;
+          throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+        }
+        if (total === 0) {
+          throw Object.assign(new Error("empty body"), { code: "EMPTY_BODY" });
+        }
+        return { chunks: [bytes], byteLength: total };
+      }
+
+      try {
+        while (true) {
+          const part = await reader.read();
+          if (part.done) {
+            break;
+          }
+          const chunk = part.value instanceof Uint8Array ? part.value : new Uint8Array(part.value);
+          total += chunk.byteLength;
+          entry.accountedBytes = Math.max(declared || 0, total);
+          if (cachedBytes + reservedBytes() > byteLimit) {
+            abortEntry(entry, "byte-limit");
+            try { await reader.cancel(); } catch (_) { /* cancellation is best effort */ }
+            throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+          }
+          chunks.push(chunk);
+        }
+      } finally {
+        try { reader.releaseLock(); } catch (_) { /* not all readers expose it */ }
+      }
+      if (total === 0) {
+        throw Object.assign(new Error("empty body"), { code: "EMPTY_BODY" });
+      }
+      return { chunks, byteLength: total };
+    }
+
+    async function download(entry) {
+      const ownGeneration = entry.generation;
+      const byteLimit = policy.livePrefetchCacheMiB * 1024 * 1024;
+      try {
+        const response = await nativeFetch(entry.url, {
+          method: "GET",
+          headers: entry.headers,
+          credentials: entry.credentials,
+          mode: entry.mode,
+          cache: entry.cache,
+          redirect: entry.redirect,
+          integrity: entry.integrity,
+          referrer: entry.referrer,
+          referrerPolicy: entry.referrerPolicy,
+          keepalive: entry.keepalive,
+          signal: entry.controller.signal
+        });
+        if (ownGeneration !== generation || entry.controller.signal.aborted) {
+          return;
+        }
+        if (!responseIsUsable(response)) {
+          if (urlIsInCurrentWindow(entry.url)) {
+            failedUrls.add(entry.url);
+          }
+          metric(entry, "response-rejected", 0);
+          return;
+        }
+        const init = safeResponseInit(response);
+        const body = await readOwnedResponse(response, entry, byteLimit);
+        if (ownGeneration !== generation || entry.controller.signal.aborted) {
+          return;
+        }
+        const otherBytes = reservedBytes() - entry.accountedBytes;
+        if (cachedBytes + otherBytes + body.byteLength > byteLimit) {
+          throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+        }
+        entry.accountedBytes = 0;
+        const previous = cache.get(entry.key);
+        if (previous) {
+          cachedBytes -= previous.byteLength;
+        }
+        cache.set(entry.key, {
+          key: entry.key,
+          url: entry.url,
+          sequence: entry.sequence,
+          duration: entry.duration,
+          playlistUrl: entry.playlistUrl,
+          chunks: body.chunks,
+          byteLength: body.byteLength,
+          init
+        });
+        cachedBytes += body.byteLength;
+        metric(entry, "stored", body.byteLength);
+      } catch (error) {
+        if (ownGeneration === generation) {
+          const byteLimitFailure = error && error.code === "BYTE_LIMIT";
+          const activelyCancelled = entry.controller.signal.aborted && !byteLimitFailure;
+          if (!activelyCancelled && urlIsInCurrentWindow(entry.url)) {
+            failedUrls.add(entry.url);
+          }
+          metric(entry, byteLimitFailure ? "byte-limit" :
+            entry.abortReason || (error && error.name === "AbortError" ? "aborted" : "fetch-failed"), entry.accountedBytes);
+          if (byteLimitFailure) {
+            abortEntry(entry, "byte-limit");
+          }
+        }
+      } finally {
+        if (inFlight.get(entry.key) === entry) {
+          inFlight.delete(entry.key);
+        }
+        entry.accountedBytes = 0;
+        pump();
+      }
+    }
+
+    function pump() {
+      if (!enabled || disposed) {
+        return;
+      }
+      while (queue.length && inFlight.size < policy.livePrefetchConcurrency) {
+        const entry = queue.shift();
+        if (entry.generation !== generation || entry.controller.signal.aborted) {
+          continue;
+        }
+        inFlight.set(entry.key, entry);
+        void download(entry);
+      }
+    }
+
+    function enqueue(snapshot, segment, sourceMeta) {
+      if (entryCount() >= policy.livePrefetchMaxSegments || failedUrls.has(segment.url) ||
+          ownedUrls().has(segment.url)) {
+        return;
+      }
+      const request = requestForSegment(segment, sourceMeta);
+      if (!isSafeGet(request)) {
+        return;
+      }
+      const controller = createController();
+      queue.push({
+        key: request.fingerprint,
+        url: request.url,
+        headers: safeRequestHeaders(request),
+        credentials: request.credentials,
+        mode: request.mode,
+        cache: request.cache,
+        redirect: request.redirect,
+        integrity: request.integrity,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        keepalive: request.keepalive,
+        sequence: segment.sequence,
+        duration: segment.duration,
+        playlistUrl: snapshot.url,
+        generation,
+        controller,
+        accountedBytes: 0,
+        abortReason: ""
+      });
+    }
+
+    function evictOldSnapshot(playlistUrl, parsed) {
+      const current = new Set(parsed.segments.map(function key(segment) {
+        return segment.sequence + "\n" + segment.url;
+      }));
+      queue = queue.filter(function keep(entry) {
+        if (entry.playlistUrl !== playlistUrl || current.has(entry.sequence + "\n" + entry.url)) {
+          return true;
+        }
+        abortEntry(entry, "playlist-window");
+        return false;
+      });
+      inFlight.forEach(function evict(entry) {
+        if (entry.playlistUrl === playlistUrl && !current.has(entry.sequence + "\n" + entry.url)) {
+          abortEntry(entry, "playlist-window");
+        }
+      });
+      cache.forEach(function evict(entry, key) {
+        if (entry.playlistUrl === playlistUrl && !current.has(entry.sequence + "\n" + entry.url)) {
+          cache.delete(key);
+          cachedBytes -= entry.byteLength;
+        }
+      });
+      Array.from(knownSegments.entries()).forEach(function evict(pair) {
+        if (pair[1].playlistUrl === playlistUrl) {
+          knownSegments.delete(pair[0]);
+        }
+      });
+    }
+
+    function rebuildKnownSegments() {
+      knownSegments.clear();
+      snapshots.forEach(function addSnapshot(snapshot, playlistUrl) {
+        if (!trustedPlaylists.has(playlistUrl)) {
+          return;
+        }
+        snapshot.playlist.segments.forEach(function remember(segment) {
+          knownSegments.set(segment.url, { playlistUrl, segment, snapshot });
+        });
+      });
+    }
+
+    function clearPlaylistMediaState(playlistUrl) {
+      evictOldSnapshot(playlistUrl, { segments: [] });
+      snapshots.delete(playlistUrl);
+      rebuildKnownSegments();
+      pruneFailedUrls();
+    }
+
+    function recomputeTrustedPlaylists() {
+      const previous = trustedPlaylists;
+      const seeds = activeRoot && roots.has(activeRoot) ? [activeRoot] : Array.from(roots);
+      const reachable = new Set(seeds);
+      const pending = seeds.slice();
+      while (pending.length) {
+        const parent = pending.shift();
+        const children = playlistReferences.get(parent);
+        if (!children) {
+          continue;
+        }
+        children.forEach(function visit(child) {
+          const variants = playlistVariantReferences.get(parent);
+          const auxiliaries = playlistMediaReferences.get(parent);
+          const selected = activeVariants.get(parent);
+          if (selected && variants && variants.has(child) &&
+              !(auxiliaries && auxiliaries.has(child)) && child !== selected) {
+            return;
+          }
+          if (!reachable.has(child)) {
+            reachable.add(child);
+            pending.push(child);
+          }
+        });
+      }
+      trustedPlaylists = reachable;
+
+      previous.forEach(function removeRevision(url) {
+        if (!reachable.has(url)) {
+          playlistRevisions.delete(url);
+        }
+      });
+
+      playlistReferences.forEach(function remove(_, url) {
+        if (!reachable.has(url)) {
+          playlistReferences.delete(url);
+          playlistVariantReferences.delete(url);
+          playlistMediaReferences.delete(url);
+          activeVariants.delete(url);
+          activeVariantOrders.delete(url);
+        }
+      });
+      snapshots.forEach(function remove(_, url) {
+        if (!reachable.has(url)) {
+          snapshots.delete(url);
+        }
+      });
+      queue = queue.filter(function keep(entry) {
+        if (reachable.has(entry.playlistUrl)) {
+          return true;
+        }
+        abortEntry(entry, "playlist-untrusted");
+        return false;
+      });
+      inFlight.forEach(function abortUntrusted(entry) {
+        if (entry.generation === generation && !reachable.has(entry.playlistUrl)) {
+          abortEntry(entry, "playlist-untrusted");
+        }
+      });
+      activePlaylistReads.forEach(function cancelUntrusted(observation) {
+        if (observation.generation === generation && !reachable.has(observation.meta.url)) {
+          cancelPlaylistRead(observation);
+        }
+      });
+      cache.forEach(function remove(entry, key) {
+        if (!reachable.has(entry.playlistUrl)) {
+          cache.delete(key);
+          cachedBytes -= entry.byteLength;
+        }
+      });
+      rebuildKnownSegments();
+      pruneFailedUrls();
+    }
+
+    function activateVariantRequest(url) {
+      const orders = [];
+      let changed = false;
+      playlistVariantReferences.forEach(function inspect(variants, parent) {
+        const auxiliaries = playlistMediaReferences.get(parent);
+        if (!trustedPlaylists.has(parent) || !variants.has(url) ||
+            (auxiliaries && auxiliaries.has(url))) {
+          return;
+        }
+        if (activeVariants.get(parent) !== url) {
+          activeVariants.set(parent, url);
+          changed = true;
+        }
+        const order = ++variantRequestCounter;
+        activeVariantOrders.set(parent, order);
+        orders.push({ parent, url, order });
+      });
+      if (changed) {
+        recomputeTrustedPlaylists();
+      }
+      return orders;
+    }
+
+    function activateRoot(url) {
+      if (!roots.has(url) || activeRoot === url) {
+        return;
+      }
+      activeRoot = url;
+      recomputeTrustedPlaylists();
+    }
+
+    function clearForProtocolSwitch(reason) {
+      clearRuntimeState(reason);
+      activeRoot = null;
+      trustedPlaylists = new Set(roots);
+    }
+
+    function beginPlaylistObservation(meta, response) {
+      if (!roots.has(meta.url) && !trustedPlaylists.has(meta.url)) {
+        return;
+      }
+      if (roots.has(meta.url)) {
+        activateRoot(meta.url);
+      }
+      const observation = {
+        meta,
+        generation,
+        revision: ++playlistRevisionCounter,
+        reader: null,
+        accountedBytes: 0,
+        cancelRequested: false,
+        cancelPromise: null
+      };
+      playlistRevisions.set(meta.url, observation.revision);
+      activePlaylistReads.forEach(function cancelOlder(active) {
+        if (active.meta.url === meta.url && active.revision < observation.revision) {
+          cancelPlaylistRead(active);
+        }
+      });
+      if (!response || response.status !== 200 || response.ok !== true || typeof response.clone !== "function") {
+        return;
+      }
+      let clone;
+      try {
+        clone = response.clone();
+      } catch (_) {
+        return;
+      }
+      const body = clone && clone.body;
+      if (!body || typeof body.getReader !== "function") {
+        discardPlaylistClone(clone);
+        return;
+      }
+      try {
+        observation.reader = body.getReader();
+      } catch (_) {
+        discardPlaylistClone(clone);
+        return;
+      }
+      if (!observation.reader || typeof observation.reader.read !== "function" ||
+          typeof observation.reader.cancel !== "function") {
+        try { observation.reader && observation.reader.releaseLock(); } catch (_) { /* unusable reader */ }
+        return;
+      }
+      startPlaylistRead(observation);
+    }
+
+    function startPlaylistRead(observation) {
+      const meta = observation.meta;
+      if (observation.generation !== generation ||
+          observation.revision !== playlistRevisions.get(meta.url) ||
+          (!roots.has(meta.url) && !trustedPlaylists.has(meta.url))) {
+        cancelPlaylistRead(observation);
+        return;
+      }
+      activePlaylistReads.add(observation);
+      void (async function readPlaylist() {
+        let text = "";
+        try {
+          const decoder = new TextDecoderImpl("utf-8");
+          const byteLimit = policy.livePrefetchCacheMiB * 1024 * 1024;
+          while (true) {
+            const part = await observation.reader.read();
+            if (part.done) {
+              text += decoder.decode();
+              break;
+            }
+            const chunk = part.value instanceof Uint8Array ? part.value : new Uint8Array(part.value);
+            observation.accountedBytes += chunk.byteLength;
+            activePlaylistBytes += chunk.byteLength;
+            if (cachedBytes + reservedBytes() > byteLimit) {
+              await cancelPlaylistRead(observation);
+              throw Object.assign(new Error("byte limit"), { code: "BYTE_LIMIT" });
+            }
+            text += decoder.decode(chunk, { stream: true });
+          }
+          const normalized = String(text).replace(/^\uFEFF/, "");
+          if (!/^#EXTM3U(?:\r?\n|$)/.test(normalized)) {
+            return;
+          }
+          const parsed = LiveCore.parsePlaylist(meta.url, normalized);
+          if (observation.generation !== generation ||
+              observation.revision !== playlistRevisions.get(meta.url) ||
+              !enabled || disposed || (!roots.has(meta.url) && !trustedPlaylists.has(meta.url))) {
+            return;
+          }
+          const variants = new Set();
+          parsed.variants.forEach(function trustVariant(url) {
+            if (isHlsUrl(url)) {
+              variants.add(url);
+            }
+          });
+          const auxiliaries = new Set();
+          parsed.media.forEach(function trustAuxiliary(url) {
+            if (isHlsUrl(url)) {
+              auxiliaries.add(url);
+            }
+          });
+          const selected = activeVariants.get(meta.url);
+          if (selected && !variants.has(selected)) {
+            activeVariants.delete(meta.url);
+            activeVariantOrders.delete(meta.url);
+          }
+          const children = new Set(variants);
+          auxiliaries.forEach(function addAuxiliary(url) { children.add(url); });
+          playlistReferences.set(meta.url, children);
+          playlistVariantReferences.set(meta.url, variants);
+          playlistMediaReferences.set(meta.url, auxiliaries);
+          recomputeTrustedPlaylists();
+          if (parsed.type !== "media") {
+            clearPlaylistMediaState(meta.url);
+            return;
+          }
+          evictOldSnapshot(meta.url, parsed);
+          const snapshot = { url: meta.url, playlist: parsed };
+          snapshots.set(meta.url, snapshot);
+          rebuildKnownSegments();
+          pruneFailedUrls();
+        } catch (_) {
+          // Playlist observation never affects the player's response path.
+        } finally {
+          if (observation.cancelPromise) {
+            await observation.cancelPromise;
+          }
+          try { observation.reader.releaseLock(); } catch (_) { /* not all readers expose it */ }
+          activePlaylistReads.delete(observation);
+          activePlaylistBytes = Math.max(0, activePlaylistBytes - observation.accountedBytes);
+          observation.accountedBytes = 0;
+          pump();
+        }
+      })();
+    }
+
+    function cancelPlaylistRead(observation) {
+      if (!observation || !observation.reader) {
+        return null;
+      }
+      if (observation.cancelRequested) {
+        return observation.cancelPromise;
+      }
+      observation.cancelRequested = true;
+      try {
+        observation.cancelPromise = Promise.resolve(observation.reader.cancel()).catch(function ignoreCancelFailure() {});
+      } catch (_) {
+        observation.cancelPromise = Promise.resolve();
+      }
+      return observation.cancelPromise;
+    }
+
+    function discardPlaylistClone(clone) {
+      try {
+        const body = clone && clone.body;
+        if (body && typeof body.cancel === "function") {
+          const cancelled = body.cancel();
+          if (cancelled && typeof cancelled.catch === "function") {
+            cancelled.catch(function ignoreCancelFailure() {});
+          }
+        }
+      } catch (_) {
+        // Releasing an unreadable clone is best effort only.
+      }
+    }
+
+    function configure(next) {
+      if (disposed) {
+        return false;
+      }
+      const value = next || {};
+      const nextPolicy = LiveCore.normalizePolicy(value.policy || {});
+      const nextPlan = Array.isArray(value.plan) ? value.plan : [];
+      const nextRoots = nextPlan.map(function planUrl(item) {
+        return typeof item === "string" ? item : item && item.url;
+      }).filter(isHlsUrl).map(function normalize(url) { return new URL(url).toString(); });
+      const nextKey = JSON.stringify({ policy: nextPolicy, plan: nextPlan });
+      const changed = nextKey !== configurationKey;
+      if (changed) {
+        clearRuntimeState("configure");
+        configurationKey = nextKey;
+        activeRoot = null;
+      }
+      policy = nextPolicy;
+      roots = new Set(nextRoots);
+      if (changed || !enabled) {
+        activeRoot = null;
+        trustedPlaylists = new Set(nextRoots);
+      }
+      enabled = Boolean(nextPolicy.active && nextPolicy.livePrefetchEnabled && roots.size &&
+        typeof nativeFetch === "function" && typeof createController === "function" &&
+        typeof createResponse === "function" && typeof ReadableStreamImpl === "function" &&
+        typeof TextDecoderImpl === "function");
+      if (!enabled) {
+        clearRuntimeState("disabled");
+      }
+      return enabled;
+    }
+
+    function scheduleAfterCursor(meta, known) {
+      const snapshot = snapshots.get(known.playlistUrl);
+      if (!snapshot || snapshot !== known.snapshot) {
+        return;
+      }
+      const buffered = bufferedSeconds(meta);
+      if (buffered === null) {
+        return;
+      }
+      const reservedUrls = ownedUrls();
+      let cursor = known.segment;
+      if (hasOwn.call(meta, "bufferedSeconds") && isBilibiliLiveFmp4Url(known.segment.url)) {
+        const segments = snapshot.playlist.segments;
+        let index = segments.findIndex(function current(segment) {
+          return segment.sequence === cursor.sequence && segment.url === cursor.url;
+        });
+        const futureCount = index >= 0 ? segments.length - index - 1 : 0;
+        if (futureCount < 2) {
+          return;
+        }
+        const leadCount = Math.min(2, futureCount - 1);
+        for (let lead = 0; lead < leadCount; lead += 1) {
+          const next = index >= 0 ? segments[index + 1] : null;
+          if (!next || next.discontinuityBefore || next.mapUrl !== cursor.mapUrl) {
+            break;
+          }
+          cursor = next;
+          index += 1;
+        }
+      }
+      const planned = LiveCore.planPrefetch(snapshot.playlist, cursor, buffered, {
+        reservedUrls,
+        reservedDuration: ownedDuration(),
+        cachedBytes,
+        inFlightBytes: reservedBytes()
+      }, policy);
+      planned.forEach(function schedule(segment) { enqueue(snapshot, segment, meta); });
+      pump();
+    }
+
+    function releaseDelivery(delivery) {
+      if (!delivery || delivery.released) {
+        return;
+      }
+      delivery.released = true;
+      delivered.delete(delivery);
+      deliveredBytes = Math.max(0, deliveredBytes - delivery.remainingBytes);
+      delivery.remainingBytes = 0;
+      delivery.chunks.length = 0;
+      if (delivery.onRelease) {
+        try { delivery.onRelease(); } catch (_) { /* playback consumption cannot affect the player */ }
+      }
+      pump();
+    }
+
+    function responseBody(delivery) {
+      if (typeof ReadableStreamImpl !== "function") {
+        throw new Error("ReadableStream is unavailable");
+      }
+      return new ReadableStreamImpl({
+        pull(controller) {
+          if (delivery.pendingBytes) {
+            delivery.remainingBytes = Math.max(0, delivery.remainingBytes - delivery.pendingBytes);
+            deliveredBytes = Math.max(0, deliveredBytes - delivery.pendingBytes);
+            delivery.pendingBytes = 0;
+          }
+          if (delivery.index >= delivery.chunks.length) {
+            controller.close();
+            releaseDelivery(delivery);
+            return;
+          }
+          const chunk = delivery.chunks[delivery.index];
+          delivery.chunks[delivery.index] = null;
+          delivery.index += 1;
+          delivery.pendingBytes = chunk.byteLength;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          releaseDelivery(delivery);
+        }
+      }, { highWaterMark: 0 });
+    }
+
+    function beforeFetch(rawMeta) {
+      const meta = normalizeMeta(rawMeta);
+      if (!meta || !isFetchMeta(meta)) {
+        return null;
+      }
+      bindRequest(rawMeta, meta);
+      if (!enabled || disposed) {
+        return null;
+      }
+      if (meta.kind === "flv") {
+        clearForProtocolSwitch("flv");
+        return null;
+      }
+      if (!isSafeGet(meta) || meta.kind !== "segment") {
+        return null;
+      }
+      inFlight.forEach(function collide(entry) {
+        if (entry.url === meta.url) {
+          abortEntry(entry, "player-collision");
+        }
+      });
+      queue = queue.filter(function cancelQueued(entry) {
+        if (entry.url !== meta.url) {
+          return true;
+        }
+        abortEntry(entry, "player-collision");
+        return false;
+      });
+      const entry = cache.get(meta.fingerprint);
+      if (!entry || entry.url !== meta.url) {
+        return null;
+      }
+      cache.delete(meta.fingerprint);
+      cachedBytes -= entry.byteLength;
+      metric(entry, "hit", entry.byteLength);
+      const known = knownSegments.get(meta.url);
+      const delivery = {
+        url: entry.url,
+        duration: entry.duration,
+        chunks: entry.chunks,
+        byteLength: entry.byteLength,
+        remainingBytes: entry.byteLength,
+        pendingBytes: 0,
+        index: 0,
+        released: false,
+        onRelease: known ? function replenishAfterConsumption() {
+          if (enabled && !disposed) {
+            scheduleAfterCursor(meta, known);
+          }
+        } : null
+      };
+      delivered.add(delivery);
+      deliveredBytes += delivery.byteLength;
+      try {
+        const response = createResponse(responseBody(delivery), entry.init);
+        if (known) {
+          void scheduleAfterCursor(meta, known);
+        }
+        return response;
+      } catch (_) {
+        releaseDelivery(delivery);
+        return null;
+      }
+    }
+
+    function observeResponse(rawMeta, response) {
+      const meta = normalizeMeta(rawMeta);
+      const binding = responseBinding(rawMeta);
+      if (!enabled || disposed || !meta || !isFetchMeta(meta) || meta.kind === "flv" ||
+          !bindingIsCurrent(binding)) {
+        return response;
+      }
+      if (meta.kind === "playlist") {
+        beginPlaylistObservation(meta, response);
+        return response;
+      }
+      if (meta.kind !== "segment" || !isSafeGet(meta)) {
+        return response;
+      }
+      const known = knownSegments.get(meta.url);
+      if (!known || !response || response.status !== 200 || response.ok !== true) {
+        return response;
+      }
+      try { scheduleAfterCursor(meta, known); } catch (_) { /* playback must continue */ }
+      return response;
+    }
+
+    function reset(reason) {
+      clearRuntimeState(reason || "reset");
+      enabled = false;
+      activeRoot = null;
+    }
+
+    function dispose() {
+      if (disposed) {
+        return;
+      }
+      clearRuntimeState("dispose");
+      disposed = true;
+      enabled = false;
+      roots.clear();
+    }
+
+    return { configure, beforeFetch, observeResponse, reset, dispose };
+  }
+
+  return { createLivePrefetchRuntime };
+});


### PR DESCRIPTION
## 变更说明

- 新增直播 HLS 稳定性模块，解析主播放列表与媒体播放列表，并按播放位置预加载后续分片。
- 增加并发数、缓存条目、缓存字节和预加载时长限制，避免预加载无限占用网络与内存。
- 在播放源切换、页面隐藏、视频替换和配置变化时清理或暂停旧任务。
- 过滤直播播放信息中的慢速节点，同时保留最后一个可用地址并保持签名参数完整。
- 增加直播模式、预加载参数及其配置迁移与界面控制。