### PR TITLE
修复特殊路径构建与备用地址响应返回

### DIFF
--- a/dist/bilibili-accelerator.user.js
+++ b/dist/bilibili-accelerator.user.js
@@ -1059,13 +1059,21 @@
   function mergeBackups(entry, key, base) {
     const alts = core.alternativesFor(base, config, backupPool());
     if (!alts.length) {
-      return;
+      return false;
     }
     const existing = Array.isArray(entry[key]) ? entry[key] : [];
     const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
       return arr.indexOf(u) === i;
     });
-    entry[key] = merged.slice(0, 8);
+    const next = merged.slice(0, 8);
+    const changed = next.length !== existing.length || next.some(function differs(u, i) {
+      return u !== existing[i];
+    });
+    if (!changed) {
+      return false;
+    }
+    entry[key] = next;
+    return true;
   }
 
   // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
@@ -1076,8 +1084,9 @@
   // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     const containers = [
       payload.data,
       payload.result,
@@ -1088,15 +1097,21 @@
       if (!container || typeof container !== "object") {
         return;
       }
-      enrichDash(container.dash);
-      enrichDurl(container.durl);
+      if (enrichDash(container.dash)) {
+        changed = true;
+      }
+      if (enrichDurl(container.durl)) {
+        changed = true;
+      }
     });
+    return changed;
   }
 
   function enrichDash(dash) {
     if (!dash || typeof dash !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     ["video", "audio"].forEach(function eachKind(kind) {
       const list = dash[kind];
       if (!Array.isArray(list)) {
@@ -1107,24 +1122,33 @@
           return;
         }
         if (typeof entry.baseUrl === "string") {
-          mergeBackups(entry, "backupUrl", entry.baseUrl);
+          if (mergeBackups(entry, "backupUrl", entry.baseUrl)) {
+            changed = true;
+          }
         }
         if (typeof entry.base_url === "string") {
-          mergeBackups(entry, "backup_url", entry.base_url);
+          if (mergeBackups(entry, "backup_url", entry.base_url)) {
+            changed = true;
+          }
         }
       });
     });
+    return changed;
   }
 
   function enrichDurl(durl) {
     if (!Array.isArray(durl)) {
-      return;
+      return false;
     }
+    let changed = false;
     durl.forEach(function eachEntry(entry) {
       if (entry && typeof entry.url === "string") {
-        mergeBackups(entry, "backup_url", entry.url);
+        if (mergeBackups(entry, "backup_url", entry.url)) {
+          changed = true;
+        }
       }
     });
+    return changed;
   }
 
   function rewritePayload(payload, source) {
@@ -1285,15 +1309,16 @@
           let parsed;
           const tracker = { changed: false, rewrites: [] };
           let live = { changed: false, rewrites: [] };
+          let backupsChanged = false;
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            backupsChanged = enrichBackups(parsed);
             live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed && !live.changed) {
+          if (!tracker.changed && !backupsChanged && !live.changed) {
             rememberSample(parsed);
             return response;
           }
@@ -1370,10 +1395,10 @@
             const parsed = nativeJsonParse(text);
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            const backupsChanged = enrichBackups(parsed);
             const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed && !live.changed) {
+            if (!tracker.changed && !backupsChanged && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);

--- a/dist/extension/bili-accelerator.page.js
+++ b/dist/extension/bili-accelerator.page.js
@@ -1042,13 +1042,21 @@
   function mergeBackups(entry, key, base) {
     const alts = core.alternativesFor(base, config, backupPool());
     if (!alts.length) {
-      return;
+      return false;
     }
     const existing = Array.isArray(entry[key]) ? entry[key] : [];
     const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
       return arr.indexOf(u) === i;
     });
-    entry[key] = merged.slice(0, 8);
+    const next = merged.slice(0, 8);
+    const changed = next.length !== existing.length || next.some(function differs(u, i) {
+      return u !== existing[i];
+    });
+    if (!changed) {
+      return false;
+    }
+    entry[key] = next;
+    return true;
   }
 
   // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
@@ -1059,8 +1067,9 @@
   // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     const containers = [
       payload.data,
       payload.result,
@@ -1071,15 +1080,21 @@
       if (!container || typeof container !== "object") {
         return;
       }
-      enrichDash(container.dash);
-      enrichDurl(container.durl);
+      if (enrichDash(container.dash)) {
+        changed = true;
+      }
+      if (enrichDurl(container.durl)) {
+        changed = true;
+      }
     });
+    return changed;
   }
 
   function enrichDash(dash) {
     if (!dash || typeof dash !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     ["video", "audio"].forEach(function eachKind(kind) {
       const list = dash[kind];
       if (!Array.isArray(list)) {
@@ -1090,24 +1105,33 @@
           return;
         }
         if (typeof entry.baseUrl === "string") {
-          mergeBackups(entry, "backupUrl", entry.baseUrl);
+          if (mergeBackups(entry, "backupUrl", entry.baseUrl)) {
+            changed = true;
+          }
         }
         if (typeof entry.base_url === "string") {
-          mergeBackups(entry, "backup_url", entry.base_url);
+          if (mergeBackups(entry, "backup_url", entry.base_url)) {
+            changed = true;
+          }
         }
       });
     });
+    return changed;
   }
 
   function enrichDurl(durl) {
     if (!Array.isArray(durl)) {
-      return;
+      return false;
     }
+    let changed = false;
     durl.forEach(function eachEntry(entry) {
       if (entry && typeof entry.url === "string") {
-        mergeBackups(entry, "backup_url", entry.url);
+        if (mergeBackups(entry, "backup_url", entry.url)) {
+          changed = true;
+        }
       }
     });
+    return changed;
   }
 
   function rewritePayload(payload, source) {
@@ -1268,15 +1292,16 @@
           let parsed;
           const tracker = { changed: false, rewrites: [] };
           let live = { changed: false, rewrites: [] };
+          let backupsChanged = false;
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            backupsChanged = enrichBackups(parsed);
             live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed && !live.changed) {
+          if (!tracker.changed && !backupsChanged && !live.changed) {
             rememberSample(parsed);
             return response;
           }
@@ -1353,10 +1378,10 @@
             const parsed = nativeJsonParse(text);
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            const backupsChanged = enrichBackups(parsed);
             const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed && !live.changed) {
+            if (!tracker.changed && !backupsChanged && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,7 +1,8 @@
 import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = path.resolve(new URL("..", import.meta.url).pathname);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const dist = path.join(root, "dist");
 const extensionDist = path.join(dist, "extension");
 

--- a/src/page/bili-accelerator.page.js
+++ b/src/page/bili-accelerator.page.js
@@ -348,13 +348,21 @@
   function mergeBackups(entry, key, base) {
     const alts = core.alternativesFor(base, config, backupPool());
     if (!alts.length) {
-      return;
+      return false;
     }
     const existing = Array.isArray(entry[key]) ? entry[key] : [];
     const merged = alts.concat(existing).filter(function uniq(u, i, arr) {
       return arr.indexOf(u) === i;
     });
-    entry[key] = merged.slice(0, 8);
+    const next = merged.slice(0, 8);
+    const changed = next.length !== existing.length || next.some(function differs(u, i) {
+      return u !== existing[i];
+    });
+    if (!changed) {
+      return false;
+    }
+    entry[key] = next;
+    return true;
   }
 
   // Add host-swapped alternatives to DASH/durl entries so Bilibili's own
@@ -365,8 +373,9 @@
   // snake_case (base_url/backup_url).
   function enrichBackups(payload) {
     if (config.selection !== "auto" || !payload || typeof payload !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     const containers = [
       payload.data,
       payload.result,
@@ -377,15 +386,21 @@
       if (!container || typeof container !== "object") {
         return;
       }
-      enrichDash(container.dash);
-      enrichDurl(container.durl);
+      if (enrichDash(container.dash)) {
+        changed = true;
+      }
+      if (enrichDurl(container.durl)) {
+        changed = true;
+      }
     });
+    return changed;
   }
 
   function enrichDash(dash) {
     if (!dash || typeof dash !== "object") {
-      return;
+      return false;
     }
+    let changed = false;
     ["video", "audio"].forEach(function eachKind(kind) {
       const list = dash[kind];
       if (!Array.isArray(list)) {
@@ -396,24 +411,33 @@
           return;
         }
         if (typeof entry.baseUrl === "string") {
-          mergeBackups(entry, "backupUrl", entry.baseUrl);
+          if (mergeBackups(entry, "backupUrl", entry.baseUrl)) {
+            changed = true;
+          }
         }
         if (typeof entry.base_url === "string") {
-          mergeBackups(entry, "backup_url", entry.base_url);
+          if (mergeBackups(entry, "backup_url", entry.base_url)) {
+            changed = true;
+          }
         }
       });
     });
+    return changed;
   }
 
   function enrichDurl(durl) {
     if (!Array.isArray(durl)) {
-      return;
+      return false;
     }
+    let changed = false;
     durl.forEach(function eachEntry(entry) {
       if (entry && typeof entry.url === "string") {
-        mergeBackups(entry, "backup_url", entry.url);
+        if (mergeBackups(entry, "backup_url", entry.url)) {
+          changed = true;
+        }
       }
     });
+    return changed;
   }
 
   function rewritePayload(payload, source) {
@@ -574,15 +598,16 @@
           let parsed;
           const tracker = { changed: false, rewrites: [] };
           let live = { changed: false, rewrites: [] };
+          let backupsChanged = false;
           try {
             parsed = nativeJsonParse(text);
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            backupsChanged = enrichBackups(parsed);
             live = core.filterLiveUrlInfo(parsed, config);
           } catch (_) {
             return response;
           }
-          if (!tracker.changed && !live.changed) {
+          if (!tracker.changed && !backupsChanged && !live.changed) {
             rememberSample(parsed);
             return response;
           }
@@ -659,10 +684,10 @@
             const parsed = nativeJsonParse(text);
             const tracker = { changed: false, rewrites: [] };
             core.rewriteObject(parsed, config, tracker);
-            enrichBackups(parsed);
+            const backupsChanged = enrichBackups(parsed);
             const live = core.filterLiveUrlInfo(parsed, config);
             rememberSample(parsed);
-            if (!tracker.changed && !live.changed) {
+            if (!tracker.changed && !backupsChanged && !live.changed) {
               return;
             }
             const rewrittenText = JSON.stringify(parsed);

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { cp, mkdtemp, readFile, rm } = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+test("builds userscript and extension page from a path with spaces and percent signs", async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "bilibili build% "));
+
+  try {
+    await Promise.all([
+      cp(path.join(projectRoot, "scripts"), path.join(temporaryRoot, "scripts"), { recursive: true }),
+      cp(path.join(projectRoot, "src"), path.join(temporaryRoot, "src"), { recursive: true }),
+      cp(path.join(projectRoot, "package.json"), path.join(temporaryRoot, "package.json")),
+      cp(path.join(projectRoot, "README.md"), path.join(temporaryRoot, "README.md")),
+      cp(path.join(projectRoot, "README.en.md"), path.join(temporaryRoot, "README.en.md"))
+    ]);
+
+    const result = spawnSync(process.execPath, [path.join(temporaryRoot, "scripts", "build.mjs")], {
+      cwd: os.tmpdir(),
+      encoding: "utf8"
+    });
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const [userscript, extensionPage] = await Promise.all([
+      readFile(path.join(temporaryRoot, "dist", "bilibili-accelerator.user.js"), "utf8"),
+      readFile(path.join(temporaryRoot, "dist", "extension", "bili-accelerator.page.js"), "utf8")
+    ]);
+
+    assert.match(userscript, /Bilibili Accelerator/);
+    assert.ok(extensionPage.length > 0);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/test/v2-page.test.js
+++ b/test/v2-page.test.js
@@ -42,6 +42,24 @@ function loadPage(extra) {
   return sandbox;
 }
 
+function assertOnlyBackupEnrichmentCanChange(sandbox, payload) {
+  const probe = JSON.parse(JSON.stringify(payload));
+  const tracker = { changed: false, rewrites: [] };
+  sandbox.BiliAcceleratorCore.rewriteObject(
+    probe,
+    sandbox.BiliAccelerator.getConfig(),
+    tracker
+  );
+  const live = sandbox.BiliAcceleratorCore.filterLiveUrlInfo(
+    probe,
+    sandbox.BiliAccelerator.getConfig()
+  );
+
+  assert.equal(tracker.changed, false, "the primary URL is already an official CDN URL");
+  assert.equal(live.changed, false, "the payload has no live url_info entries to filter");
+  assert.deepEqual(probe, payload, "the two core rewrite passes leave the payload unchanged");
+}
+
 function loadPageWithVideo() {
   const core = fs.readFileSync(path.join(__dirname, "../src/core/rewrite.js"), "utf8");
   const page = fs.readFileSync(path.join(__dirname, "../src/page/bili-accelerator.page.js"), "utf8");
@@ -271,6 +289,70 @@ test("fetch media responses are returned without cloning or reading their bodies
 
   assert.equal(result, response);
   assert.equal(cloneCalls, 0);
+});
+
+test("fetch returns JSON when backup enrichment is the only response change", async () => {
+  const payload = {
+    data: { dash: { video: [{
+      baseUrl: "https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/v.m4s?x=1",
+      backupUrl: []
+    }] } }
+  };
+  const body = JSON.stringify(payload);
+  const original = new Response(body, {
+    headers: { "content-type": "application/json", "content-length": String(body.length) }
+  });
+  const sandbox = loadPage({ fetch: async () => original });
+  assertOnlyBackupEnrichmentCanChange(sandbox, payload);
+
+  const result = await sandbox.fetch("https://api.bilibili.com/x/player/playurl?avid=1&cid=2");
+
+  assert.notEqual(result, original, "backup-only enrichment must replace the original response");
+  const rewritten = JSON.parse(await result.text());
+  const entry = rewritten.data.dash.video[0];
+  assert.equal(entry.baseUrl, payload.data.dash.video[0].baseUrl);
+  assert.ok(entry.backupUrl.length > 0);
+});
+
+test("XHR exposes JSON when backup enrichment is the only response change", () => {
+  const payload = {
+    data: { durl: [{
+      url: "https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/v.mp4?x=1",
+      backup_url: []
+    }] }
+  };
+  const body = JSON.stringify(payload);
+
+  class BackupOnlyXHR {
+    constructor() {
+      this.listeners = new Map();
+      this.responseText = body;
+      this.response = body;
+      this.responseType = "";
+    }
+    open(method, url) { this._method = method; this._url = url; }
+    send() {
+      const listener = this.listeners.get("load");
+      if (listener) listener();
+    }
+    addEventListener(type, listener) { this.listeners.set(type, listener); }
+    getResponseHeader(name) {
+      return name.toLowerCase() === "content-type" ? "application/json" : null;
+    }
+  }
+
+  const sandbox = loadPage({ XMLHttpRequest: BackupOnlyXHR });
+  assertOnlyBackupEnrichmentCanChange(sandbox, payload);
+  const xhr = new sandbox.XMLHttpRequest();
+  xhr.open("GET", "https://api.bilibili.com/x/player/playurl?avid=1&cid=2");
+  xhr.send();
+
+  assert.notEqual(xhr.responseText, body,
+    "backup-only enrichment must replace the original responseText");
+  const rewritten = JSON.parse(xhr.responseText);
+  const entry = rewritten.data.durl[0];
+  assert.equal(entry.url, payload.data.durl[0].url);
+  assert.ok(entry.backup_url.length > 0);
 });
 
 test("a hidden tab defers stall recovery; returning re-checks it", () => {


### PR DESCRIPTION
## 变更

- 使用 `fileURLToPath(import.meta.url)` 解析构建脚本目录，修复 Windows 盘符以及包含空格、`%` 的路径。
- 让备用地址扩充函数返回真实变化状态；仅新增备用地址时，Fetch 与 XHR 也会向调用方返回改写后的 JSON。
- 同步提交用户脚本和扩展页面生成产物。

## 拆分说明

这是从 #31 按审阅意见拆出的两个独立修复，不包含直播协议排序、预读取、版本升级或文档变更。两个修复分别保留为独立提交。

## 测试

- Node.js 22：`node --test`，77/77 通过
- Node.js 22：`node scripts/build.mjs` 通过
- `git diff --exit-code -- dist` 通过
- `git diff HEAD --check` 通过
- 构建测试覆盖同时包含空格和 `%` 的临时项目路径
- 页面测试覆盖 backup-only 的 Fetch 与 XHR 返回路径